### PR TITLE
fix(ci): add missing code-export.yaml to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,14 @@ jobs:
             | `subtask-orchestrator-export.yaml` | Atomic subtask decomposition |
             | `architect-export.yaml` | Technical design & planning |
             | `ask-export.yaml` | Research & intelligence gathering |
+            | `code-export.yaml` | Implementation & code modification |
             | `git-export.yaml` | Conventional commits & version control |
           files: |
             agents/orchestrator-export.yaml
             agents/subtask-orchestrator-export.yaml
             agents/architect-export.yaml
             agents/ask-export.yaml
+            agents/code-export.yaml
             agents/git-export.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Code mode export file was present in the repository but not included in GitHub Release artifacts. Added to both the release body table and the files list."