### PR TITLE
feat(agents): add adaptive user-skill evaluation to architect and code modes

### DIFF
--- a/agents/architect-export.yaml
+++ b/agents/architect-export.yaml
@@ -35,10 +35,12 @@ customModes:
       tells you what to do after loading. Trust the instructions and follow
       them.
 
-      Skill evaluation: After loading required skills (forge, caveman),
-      review available skills using the `skill` tool. If any user-installed
-      skills are relevant to the current planning task (e.g., architecture
-      patterns, domain-specific methodologies), load and apply them.
+      Skill evaluation: After the forge skill and its auto-loaded
+      dependencies are active, review the available skills listed in
+      your system context. If any user-installed skills beyond the
+      pipeline defaults are relevant to the current planning task
+      (e.g., architecture patterns, domain-specific methodologies),
+      load them using the `skill` tool and apply their guidance.
 
       Flow: (1) If intel is missing or insufficient, use run_slash_command
       with command 'research'. (2) Use run_slash_command with command

--- a/agents/architect-export.yaml
+++ b/agents/architect-export.yaml
@@ -35,6 +35,11 @@ customModes:
       tells you what to do after loading. Trust the instructions and follow
       them.
 
+      Skill evaluation: After loading required skills (forge, caveman),
+      review available skills using the `skill` tool. If any user-installed
+      skills are relevant to the current planning task (e.g., architecture
+      patterns, domain-specific methodologies), load and apply them.
+
       Flow: (1) If intel is missing or insufficient, use run_slash_command
       with command 'research'. (2) Use run_slash_command with command
       'clarify' to define the MVP scope — ask what the minimum viable

--- a/agents/architect-export.yaml
+++ b/agents/architect-export.yaml
@@ -38,8 +38,7 @@ customModes:
       Skill evaluation: After the forge skill and its auto-loaded
       dependencies are active, review the available skills listed in
       your system context. If any user-installed skills beyond the
-      pipeline defaults are relevant to the current planning task
-      (e.g., architecture patterns, domain-specific methodologies),
+      pipeline defaults are relevant to the current planning task,
       load them using the `skill` tool and apply their guidance.
 
       Flow: (1) If intel is missing or insufficient, use run_slash_command

--- a/agents/code-export.yaml
+++ b/agents/code-export.yaml
@@ -22,10 +22,12 @@ customModes:
       tells you what to do after loading. Trust the instructions and follow
       them.
 
-      Skill evaluation: After loading required skills (forge, caveman),
-      review available skills using the `skill` tool. If any user-installed
-      skills are relevant to the current task (e.g., framework patterns,
-      testing strategies, linting rules), load and apply them.
+      Skill evaluation: After the forge skill and its auto-loaded
+      dependencies are active, review the available skills listed in
+      your system context. If any user-installed skills beyond the
+      pipeline defaults are relevant to the current task (e.g.,
+      framework patterns, testing strategies, linting rules), load
+      them using the `skill` tool and apply their guidance.
 
       Flow: Implement the assigned task. On unexpected error (build/test/runtime/lint
       failure), use run_slash_command with command 'debug'. If /debug resolves

--- a/agents/code-export.yaml
+++ b/agents/code-export.yaml
@@ -22,6 +22,11 @@ customModes:
       tells you what to do after loading. Trust the instructions and follow
       them.
 
+      Skill evaluation: After loading required skills (forge, caveman),
+      review available skills using the `skill` tool. If any user-installed
+      skills are relevant to the current task (e.g., framework patterns,
+      testing strategies, linting rules), load and apply them.
+
       Flow: Implement the assigned task. On unexpected error (build/test/runtime/lint
       failure), use run_slash_command with command 'debug'. If /debug resolves
       a non-obvious issue worth preserving, run run_slash_command with command

--- a/agents/code-export.yaml
+++ b/agents/code-export.yaml
@@ -25,8 +25,7 @@ customModes:
       Skill evaluation: After the forge skill and its auto-loaded
       dependencies are active, review the available skills listed in
       your system context. If any user-installed skills beyond the
-      pipeline defaults are relevant to the current task (e.g.,
-      framework patterns, testing strategies, linting rules), load
+      pipeline defaults are relevant to the current task, load
       them using the `skill` tool and apply their guidance.
 
       Flow: Implement the assigned task. On unexpected error (build/test/runtime/lint


### PR DESCRIPTION
### Commits (3 total)
| Hash | Subject |
|------|---------|
| `02ca057` | fix(agents): refine skill evaluation instructions in architect and code modes |
| `2f1b029` | feat(agents): add adaptive skill evaluation to architect and code modes |
| `bd5d7d0` | feat(agents): add adaptive skill evaluation to architect and code modes |

### Description

#### What Changed

Adds a **Skill evaluation** step to both architect and code mode customInstructions, enabling them to discover and leverage user-installed skills beyond the pipeline defaults.

**How it works:**
1. After the forge skill and its auto-loaded dependencies (caveman, planning-and-task-breakdown) are active
2. The agent reviews available skills listed in its system context (provided by Roo Code's `<available_skills>` section)
3. If any user-installed skills are relevant to the current task, the agent loads them via the `skill` tool and applies their guidance

**Affected files:**
- `agents/architect-export.yaml` — skill evaluation for planning tasks (architecture patterns, domain methodologies)
- `agents/code-export.yaml` — skill evaluation for implementation tasks (framework patterns, testing strategies, linting rules)

#### Why

The pipeline ships with fixed skills (forge → caveman → planning-and-task-breakdown). Users may install additional skills (e.g., `architecture-patterns`, `bun`, `nuxt`, `frontend-design`) that are highly relevant to specific tasks. Without this evaluation step, agents ignore those skills entirely.

This change makes the pipeline **adapt to the user's skill environment** without requiring pipeline modifications — any installed skill that matches the task context gets loaded and applied automatically.

#### Testing
- [x] YAML syntax valid for both files
- [x] Skill evaluation paragraph placed correctly in customInstructions flow
- [x] No changes to permissions, groups, or role definitions
- [x] No impact on other modes (orchestrator, subtask-orchestrator, ask, git)
