### PR TITLE
fix(agents): remove duplicate edit groups in architect mode

### DIFF
--- a/agents/architect-export.yaml
+++ b/agents/architect-export.yaml
@@ -24,10 +24,7 @@ customModes:
       - read
       - - edit
         - fileRegex: \.md$
-          description: Markdown files only
-      - - edit
-        - fileRegex: \.memory/.*\.md$
-          description: Memory files in .memory/ only
+          description: Markdown and memory files only
       - mcp
     customInstructions: >-
       Slash commands load context + guardrails — run once per command, then


### PR DESCRIPTION
## Problem

Importing `architect-export.yaml` into Roo Code failed with:
```
Failed to import mode: Invalid mode configuration for architect: Duplicate groups are not allowed
```
The `groups` section contained two separate `- edit` entries — one for `\.md$` and one for `\.memory/.*\.md$` — which Roo Code treats as duplicates.

## Fix

Merged the two `- edit` entries into a single entry with `fileRegex: \.md$`, which already covers all markdown files including those in `.memory/`.

**Before:**
```yaml
groups:
  - read
  - - edit
    - fileRegex: \.md$
      description: Markdown files only
  - - edit
    - fileRegex: \.memory/.*\.md$
      description: Memory files in .memory/ only
  - mcp
```
**After:**
```yaml
groups:
  - read
  - - edit
    - fileRegex: \.md$
      description: Markdown and memory files only
  - mcp
```
## Validation
Verified all other agent YAML files (ask, code, git, orchestrator, subtask-orchestrator) — no duplicates found.
Import into Roo Code now succeeds without errors.