### PR TITLE
fix(commands): add memory reconciliation pre-flight to /finalize and expand orchestrator permissions

### DIFF
--- a/agents/orchestrator-export.yaml
+++ b/agents/orchestrator-export.yaml
@@ -20,8 +20,12 @@ customModes:
     groups:
       - read
       - - edit
-        - fileRegex: \.memory/.*\.md$
-          description: Memory files in .memory/ only
+        - fileRegex: \.memory/
+          description: Full edit access to .memory/ directory
+      - - edit
+        - fileRegex: ^AGENTS\.md$
+          description: AGENTS.md at project root
+      - command
     customInstructions: >-
       Slash commands load context + guardrails — run once per command, then
       follow their guidance directly. Each command's ## Important section
@@ -44,5 +48,7 @@ customModes:
       Always run /finalize before attempt_completion. Evaluate each task
       result before proceeding to the next. Verify phase checkpoints. If
       blocked, use run_slash_command with command 'plan' with failure details
-      and full state.
+      and full state. execute_command is STRICTLY limited to 'rm -rf
+      .memory/*' during /finalize cleanup — using it for ANY other command
+      is a protocol violation.
     source: global

--- a/commands/finalize.md
+++ b/commands/finalize.md
@@ -10,6 +10,32 @@ description: >
 
 All phases complete. Produce final output for human user. NOT a technical report — clear, readable summary of what was accomplished.
 
+## Pre-Flight: Memory Reconciliation
+
+Before formatting `attempt_completion`, perform these steps **in order**:
+
+### 1. Read All Memory Context
+Read every file in `.memory/` — phase files, blocker files, research files, and `memory.md`. Use `list_files` on `.memory/` to discover all files, then `read_file` each one.
+
+### 2. Verify Completeness
+Cross-reference all memory content against subtask output:
+- Every task recorded in phase files → confirmed done in output
+- Every blocker file → confirmed resolved or documented as known limitation
+- Every research finding → incorporated or explicitly scoped out
+- If gaps found → state them honestly in Known Limitations, do NOT silently skip
+
+### 3. Consolidate AGENTS.md
+Merge existing `AGENTS.md` with all `.memory/` content into one comprehensive, pipeline-agnostic `AGENTS.md`:
+- Preserve all existing sections from `AGENTS.md`
+- Incorporate relevant decisions, findings, and context from memory files
+- Remove pipeline-specific jargon — make it usable by any agent, not just Forge pipeline
+- Write the consolidated file to `AGENTS.md` at project root
+
+### 4. Clean Up Memory
+Remove all files from `.memory/` directory. The consolidated `AGENTS.md` now holds all persistent context. Use `execute_command` with `rm -rf .memory/*` to clean up.
+
+Once all four steps are done, proceed to `attempt_completion` using the Format below.
+
 ## Format
 
 `attempt_completion` result must be structured for human consumption:


### PR DESCRIPTION
Add Pre-Flight Memory Reconciliation section to commands/finalize.md that reads all .memory/ context, verifies completeness against subtask output, consolidates AGENTS.md with memory into pipeline-agnostic version, and cleans up .memory/ directory before attempt_completion.

Expand orchestrator groups in agents/orchestrator-export.yaml:
- Broaden .memory/ edit from .md-only to all file types
- Add edit access to AGENTS.md at project root
- Add command group (constrained to rm -rf .memory/* only via protocol rule)