### PR TITLE
fix(agents): merge duplicate edit groups in orchestrator mode

### DIFF
--- a/agents/orchestrator-export.yaml
+++ b/agents/orchestrator-export.yaml
@@ -20,11 +20,8 @@ customModes:
     groups:
       - read
       - - edit
-        - fileRegex: \.memory/
-          description: Full edit access to .memory/ directory
-      - - edit
-        - fileRegex: ^AGENTS\.md$
-          description: AGENTS.md at project root
+        - fileRegex: \.memory/|^AGENTS\.md$
+          description: .memory/ directory and AGENTS.md at project root
       - command
     customInstructions: >-
       Slash commands load context + guardrails — run once per command, then


### PR DESCRIPTION
Roo Code does not allow duplicate group types in the groups array. Combine two separate edit entries (\.memory/ and ^AGENTS\.md$) into a single edit entry using regex alternation: \.memory/|^AGENTS\.md$

This resolves the "Duplicate groups are not allowed" import error.