### PR TITLE
fix(forge): move skill evaluation from agent YAMLs to forge SKILL.md …

### DIFF
--- a/agents/architect-export.yaml
+++ b/agents/architect-export.yaml
@@ -32,12 +32,6 @@ customModes:
       tells you what to do after loading. Trust the instructions and follow
       them.
 
-      Skill evaluation: After the forge skill and its auto-loaded
-      dependencies are active, review the available skills listed in
-      your system context. If any user-installed skills beyond the
-      pipeline defaults are relevant to the current planning task,
-      load them using the `skill` tool and apply their guidance.
-
       Flow: (1) If intel is missing or insufficient, use run_slash_command
       with command 'research'. (2) Use run_slash_command with command
       'clarify' to define the MVP scope — ask what the minimum viable

--- a/agents/code-export.yaml
+++ b/agents/code-export.yaml
@@ -22,12 +22,6 @@ customModes:
       tells you what to do after loading. Trust the instructions and follow
       them.
 
-      Skill evaluation: After the forge skill and its auto-loaded
-      dependencies are active, review the available skills listed in
-      your system context. If any user-installed skills beyond the
-      pipeline defaults are relevant to the current task, load
-      them using the `skill` tool and apply their guidance.
-
       Flow: Implement the assigned task. On unexpected error (build/test/runtime/lint
       failure), use run_slash_command with command 'debug'. If /debug resolves
       a non-obvious issue worth preserving, run run_slash_command with command

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -10,9 +10,11 @@ description: >
 
 You are part of Forge orchestration pipeline. This skill defines how pipeline works, which commands available, how modes interact.
 
-## On Load: Activate Caveman
+## On Load: Activate Caveman + Evaluate Available Skills
 
-Immediately after loading this skill, load caveman using `skill` tool with name `caveman`. This activates token-efficient communication across all pipeline interactions. Caveman defaults to **full** intensity — drop articles, fragments OK, short synonyms, no filler.
+1. **Caveman**: Immediately load using `skill` tool with name `caveman`. Activates token-efficient communication across all pipeline interactions. Defaults to **full** intensity — drop articles, fragments OK, short synonyms, no filler.
+
+2. **Skill evaluation**: After forge + caveman active, scan `<available_skills>` block in your system context. Each entry shows `name` + `description` — match against current task. Pipeline defaults (forge, caveman) already loaded. If any **user-installed** skill beyond defaults is relevant, load via `skill` tool and apply its guidance. Skip if no match. (mostly not applying if you are an orchestrator)
 
 ## Pipeline Flow
 
@@ -123,7 +125,7 @@ Never assume downstream modes have context. Every `new_task` must be self-contai
 
 ```
 Starting a project:   run /forge-init → creates .memory/, .gitignore, AGENTS.md, git init
-Starting any task:    load 'forge' skill → load 'caveman' skill → understand pipeline + commands
+Starting any task:    load 'forge' skill → load 'caveman' skill → evaluate available skills → understand pipeline + commands
 Need user clarity:    run /clarify → structured ask_followup_question
 Need web intel:       run /web → search + read URLs via SearXNG MCP
 Need intel:           run /research → (cascades to /delegate with ask)


### PR DESCRIPTION
…On Load section

Consolidate skill evaluation logic into forge skill so all modes inherit it automatically via skill loading instead of duplicating in individual agent customInstructions.

- Add step 2 to On Load: scan <available_skills> in system context, load user-installed skills beyond pipeline defaults via skill tool
- Remove skill evaluation paragraph from architect-export.yaml
- Remove skill evaluation paragraph from code-export.yaml
- Update Quick Reference to include skill evaluation in startup flow