### PR TITLE
Feat/ask pdf mcp server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - "commands/**"
       - "skills/**"
       - "rules/**"
+      - "mcp/**"
 
 permissions:
   contents: write
@@ -41,6 +42,7 @@ jobs:
           zip -r commands.zip commands/
           zip -r skills.zip skills/
           zip -r rules.zip rules/
+          zip -r mcp.zip mcp/
 
       - name: Create GitHub Release
         if: steps.semantic.outputs.new_tag != steps.semantic.outputs.previous_tag
@@ -70,6 +72,7 @@ jobs:
             | `commands.zip` | All 13 slash commands — copy to `~/.roo/commands/` |
             | `skills.zip` | All 6 skills (forge, caveman, grill-me, planning-and-task-breakdown, deep-research, conventional-commits) — copy to `~/.roo/skills/` |
             | `rules.zip` | Native git commit guardrail rule — copy to `~/.roo/rules-git/` |
+            | `mcp.zip` | MCP server scripts (pdf-curl-server.sh) — copy to `~/.roo/mcp/` |
 
             ### Installation
 
@@ -77,6 +80,7 @@ jobs:
             2. Download `commands.zip` and extract to `~/.roo/commands/`
             3. Download `skills.zip` and extract to `~/.roo/skills/`
             4. Download `rules.zip` and extract to `~/.roo/rules-git/`
+            5. Download `mcp.zip` and extract to `~/.roo/mcp/`
           files: |
             agents/orchestrator-export.yaml
             agents/subtask-orchestrator-export.yaml
@@ -87,5 +91,6 @@ jobs:
             commands.zip
             skills.zip
             rules.zip
+            mcp.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,18 @@ All delegated agents persist relevant context to `.memory/` before completion so
 
 Every agent YAML, every command context, and every loaded skill can mark steps as **MANDATORY**. Any step so marked must be executed without exception — never skipped, deferred, or omitted. This applies globally across all modes and pipeline phases.
 
+### Mode Capabilities
+
+- `ask` mode: web research (`/web`), PDF acquisition (`/pdf`), codebase analysis, intel reports
+
+### Command Registry
+
+| Command | Purpose | Target Mode |
+|---------|---------|-------------|
+| `/web` | Web search + URL reader via SearXNG MCP | `ask` |
+| `/pdf` | PDF download via curl MCP | `ask` |
+| `/git` | Git operations (MCP-first, CLI fallback) | `git` |
+
 ## Skills
 
 All skills live in `skills/` and are loaded via the `skill` tool. Two load on startup (forge → caveman). Others load on-demand when triggered by specific commands.
@@ -99,6 +111,14 @@ All rules live in `rules/` and are installed to `~/.roo/rules-git/` via Zoo Code
 - Native rules are loaded automatically by Zoo Code when the rule's file pattern matches
 - The git commit guardrail rule **must** load `/git` via `run_slash_command` first (see rule content for enforcement details)
 
+## MCP Servers
+
+| Server | Required By | Purpose | Tools |
+|--------|-------------|---------|-------|
+| **SearXNG** | `ask` | Web search & URL reading | `searxng_web_search`, `web_url_read` |
+| **curl-download** | `ask` | PDF download from URLs | `curl_download` (1) |
+| **Git MCP** | `git` | Git operations | 20+ tools |
+
 ## Key Docs
 
 - `README.md` — Pipeline Mermaid diagrams, mode descriptions, install instructions
@@ -106,7 +126,8 @@ All rules live in `rules/` and are installed to `~/.roo/rules-git/` via Zoo Code
 - `skills/forge/SKILL.md` — Pipeline orientation, command registry, conventions
 - `skills/caveman/SKILL.md` — Token-efficient communication (auto-loaded by forge skill)
 - `skills/grill-me/SKILL.md` — Relentless interview protocol (mandatory on `/clarify`)
-- `mcp.md` — MCP server configuration (SearXNG + Git MCP)
+- `mcp.md` — MCP server configuration (SearXNG + curl-download + Git MCP)
+- `commands/pdf.md` — PDF download command via curl-download MCP
 - `rules/git/mandatory-commit-guardrail.md` — Git commit guardrails (installed to `~/.roo/rules-git/`)
 
 ## Directory Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ All rules live in `rules/` and are installed to `~/.roo/rules-git/` via Zoo Code
 |--------|-------------|---------|-------|
 | **SearXNG** | `ask` | Web search & URL reading | `searxng_web_search`, `web_url_read` |
 | **curl-download** | `ask` | PDF download from URLs | `curl_download` (1) |
-| **pdf-reader-mcp** | `ask` | Extract and parse text from PDFs | `read_pdf`, `search_pdf`, `inspect_pdf` |
+| **pdf-reader-mcp** | `ask` | Extract and parse text from PDFs | `read_pdf`, `search_pdf`, `inspect_pdf`, `ocr_pages`, `analyze_regions`, `extract_regions`, `render_page` |
 | **Git MCP** | `git` | Git operations | 20+ tools |
 
 ## Key Docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ All rules live in `rules/` and are installed to `~/.roo/rules-git/` via Zoo Code
 |--------|-------------|---------|-------|
 | **SearXNG** | `ask` | Web search & URL reading | `searxng_web_search`, `web_url_read` |
 | **curl-download** | `ask` | PDF download from URLs | `curl_download` (1) |
+| **pdf-reader-mcp** | `ask` | Extract and parse text from PDFs | `read_pdf`, `search_pdf`, `inspect_pdf` |
 | **Git MCP** | `git` | Git operations | 20+ tools |
 
 ## Key Docs
@@ -126,7 +127,7 @@ All rules live in `rules/` and are installed to `~/.roo/rules-git/` via Zoo Code
 - `skills/forge/SKILL.md` — Pipeline orientation, command registry, conventions
 - `skills/caveman/SKILL.md` — Token-efficient communication (auto-loaded by forge skill)
 - `skills/grill-me/SKILL.md` — Relentless interview protocol (mandatory on `/clarify`)
-- `mcp.md` — MCP server configuration (SearXNG + curl-download + Git MCP)
+- `mcp.md` — MCP server configuration (SearXNG + curl-download + pdf-reader-mcp + Git MCP)
 - `commands/pdf.md` — PDF download command via curl-download MCP
 - `rules/git/mandatory-commit-guardrail.md` — Git commit guardrails (installed to `~/.roo/rules-git/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Every agent YAML, every command context, and every loaded skill can mark steps a
 | Command | Purpose | Target Mode |
 |---------|---------|-------------|
 | `/web` | Web search + URL reader via SearXNG MCP | `ask` |
-| `/pdf` | PDF download via curl MCP | `ask` |
+| `/pdf` | PDF download via curl MCP + read via pdf-reader-mcp | `ask` |
 | `/git` | Git operations (MCP-first, CLI fallback) | `git` |
 
 ## Skills

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ The orchestration pipeline requires the following MCP (Model Context Protocol) s
 |--------|-------------|---------|
 | **SearXNG** | Ask | Web search & URL reading |
 | **curl-download** | Ask | PDF download from URLs (1 tool) |
-| **pdf-reader-mcp** | Ask | Extract and parse text from PDFs |
+| **pdf-reader-mcp** | Ask | Extract and parse text from PDFs (7 tools) |
 | **Git MCP** | Git | Git operations (CLI fallback) |
 
 > 💡 See [`mcp.md`](mcp.md) for full setup instructions, configuration details, and usage examples.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ All modes share `.memory/` as working memory — gitignored, local only. Read vi
 | Mode | File | Description |
 |------|------|-------------|
 | **Orchestrator** | [`agents/orchestrator-export.yaml`](agents/orchestrator-export.yaml) | Strategic entry point. Navigates Blueprint phases, delegates to subtask-orchestrator, and commits after each phase via Git. |
-| **Ask** | [`agents/ask-export.yaml`](agents/ask-export.yaml) | Intelligence specialist. Performs web research, codebase analysis, and generates "State of Intel" reports. |
+| **Ask** | [`agents/ask-export.yaml`](agents/ask-export.yaml) | Intelligence specialist. Performs web research, PDF acquisition, codebase analysis, and generates "State of Intel" reports. |
 | **Architect** | [`agents/architect-export.yaml`](agents/architect-export.yaml) | Technical leader. Creates detailed blueprints, system designs, and structured plans from gathered intelligence. |
 | **Subtask Orchestrator** | [`agents/subtask-orchestrator-export.yaml`](agents/subtask-orchestrator-export.yaml) | Dual-role specialist. (1) Planning: coordinates clarify → research → architect to produce Blueprint. (2) Execution: decomposes tasks into atomic subtasks for Code/Debug. |
 | **Code** | [`agents/code-export.yaml`](agents/code-export.yaml) | Implementation specialist. Writes, modifies, and refactors code. Delegates errors to Debug mode. |
@@ -166,6 +166,7 @@ Standardized tool call formats that cascade into each other, eliminating duplica
 | Command | Purpose | Used By |
 |---------|---------|---------|
 | `/web` | Web search + URL reader via SearXNG MCP | Ask |
+| `/pdf` | PDF download via curl MCP | Ask |
 | `/git` | Git operations (MCP-first, CLI fallback) | Git |
 
 ### Delegation Commands (cascade to `/delegate`)
@@ -255,7 +256,7 @@ See [**MCP Servers**](#-mcp-servers) below for required server setup.
 
 ## 🔄 Automated Releases
 
-This repository uses **automated semantic versioning** powered by [Conventional Commits](https://www.conventionalcommits.org/):
+This repository uses **automated semantic versioning** powered by [Conventional Commits](https://www.conventionalcommits.org):
 
 ```mermaid
 flowchart LR
@@ -290,11 +291,12 @@ flowchart LR
 
 ## 🔌 MCP Servers
 
-The orchestration pipeline requires two MCP (Model Context Protocol) servers for full functionality. These servers extend the capabilities of specific modes in the pipeline.
+The orchestration pipeline requires the following MCP (Model Context Protocol) servers for full functionality. These servers extend the capabilities of specific modes in the pipeline.
 
 | Server | Required By | Purpose |
 |--------|-------------|---------|
 | **SearXNG** | Ask | Web search & URL reading |
+| **curl-download** | Ask | PDF download from URLs (1 tool) |
 | **Git MCP** | Git | Git operations (CLI fallback) |
 
 > 💡 See [`mcp.md`](mcp.md) for full setup instructions, configuration details, and usage examples.
@@ -322,6 +324,7 @@ The orchestration pipeline requires two MCP (Model Context Protocol) servers for
 │   ├── planning.md                  # /planning — SO planning lifecycle (clarify → research → architect)
 │   ├── finalize.md                  # /finalize — human-readable output
 │   ├── web.md                       # /web — web search + URL reader
+│   ├── pdf.md                       # /pdf — PDF download via curl MCP
 │   ├── git.md                       # /git — git operations (MCP + CLI + branch setup)
 │   ├── research.md                  # /research — intel delegation
 │   ├── plan.md                      # /plan — routing to SO for planning
@@ -346,7 +349,7 @@ The orchestration pipeline requires two MCP (Model Context Protocol) servers for
 │   │   └── SKILL.md                 # Relentless user interview skill
 │   └── planning-and-task-breakdown/
 │       └── SKILL.md                 # Planning methodology skill
-├── mcp.md                          # MCP server configuration (SearXNG + Git MCP)
+├── mcp.md                          # MCP server configuration (SearXNG + curl-download + Git MCP)
 ├── CONTRIBUTING.md                  # Contribution guidelines
 ├── LICENSE                          # Apache License 2.0
 └── README.md                        # This file

--- a/README.md
+++ b/README.md
@@ -210,14 +210,16 @@ Zoo Code native rules installed to `~/.roo/rules-git/`. Loaded automatically whe
 ```bash
 git clone https://github.com/weselben/RooForge.git
 cd RooForge
-mkdir -p ~/.roo/commands ~/.roo/skills ~/.roo/rules-git
+mkdir -p ~/.roo/commands ~/.roo/skills ~/.roo/rules-git ~/.roo/mcp
 cp -rf commands/* ~/.roo/commands/
 # Only remove known RooForge skills — never rm -rf ~/.roo/skills/* to protect user-installed skills
 rm -rf ~/.roo/skills/caveman ~/.roo/skills/forge ~/.roo/skills/grill-me ~/.roo/skills/planning-and-task-breakdown ~/.roo/skills/conventional-commits
 # Only remove known RooForge rules — never rm -rf ~/.roo/rules-git/* to protect user-installed rules
 rm -rf ~/.roo/rules-git/mandatory-commit-guardrail.md
+rm -f ~/.roo/mcp/pdf-curl-server.sh
 cp -rf skills/* ~/.roo/skills/
 cp -rf rules/git/* ~/.roo/rules-git/
+cp mcp/pdf-curl-server.sh ~/.roo/mcp/
 ```
 
 To install a **specific version**, clone by tag instead:
@@ -225,14 +227,16 @@ To install a **specific version**, clone by tag instead:
 ```bash
 git clone --branch v1.2.3 --depth 1 https://github.com/weselben/RooForge.git
 cd RooForge
-mkdir -p ~/.roo/commands ~/.roo/skills ~/.roo/rules-git
+mkdir -p ~/.roo/commands ~/.roo/skills ~/.roo/rules-git ~/.roo/mcp
 cp -rf commands/* ~/.roo/commands/
 # Only remove known RooForge skills — never rm -rf ~/.roo/skills/* to protect user-installed skills
 rm -rf ~/.roo/skills/caveman ~/.roo/skills/forge ~/.roo/skills/grill-me ~/.roo/skills/planning-and-task-breakdown ~/.roo/skills/conventional-commits
 # Only remove known RooForge rules — never rm -rf ~/.roo/rules-git/* to protect user-installed rules
 rm -rf ~/.roo/rules-git/mandatory-commit-guardrail.md
+rm -f ~/.roo/mcp/pdf-curl-server.sh
 cp -rf skills/* ~/.roo/skills/
 cp -rf rules/git/* ~/.roo/rules-git/
+cp mcp/pdf-curl-server.sh ~/.roo/mcp/
 ```
 
 > **Why remove specific skills, not all?** The `rm -rf` targets only known RooForge skills (`caveman`, `conventional-commits`, `forge`, `grill-me`, `planning-and-task-breakdown`). This prevents accidental deletion of user-installed skills (e.g. via `npx skills add` or manual installs). If you add a new skill to this repo, **you must add it to the `rm -rf` line** in both install commands above.
@@ -297,6 +301,7 @@ The orchestration pipeline requires the following MCP (Model Context Protocol) s
 |--------|-------------|---------|
 | **SearXNG** | Ask | Web search & URL reading |
 | **curl-download** | Ask | PDF download from URLs (1 tool) |
+| **pdf-reader-mcp** | Ask | Extract and parse text from PDFs |
 | **Git MCP** | Git | Git operations (CLI fallback) |
 
 > 💡 See [`mcp.md`](mcp.md) for full setup instructions, configuration details, and usage examples.
@@ -349,7 +354,9 @@ The orchestration pipeline requires the following MCP (Model Context Protocol) s
 │   │   └── SKILL.md                 # Relentless user interview skill
 │   └── planning-and-task-breakdown/
 │       └── SKILL.md                 # Planning methodology skill
-├── mcp.md                          # MCP server configuration (SearXNG + curl-download + Git MCP)
+├── mcp/
+│   └── pdf-curl-server.sh          # POSIX shell script for PDF download MCP
+├── mcp.md                          # MCP server configuration (SearXNG + curl-download + pdf-reader-mcp + Git MCP)
 ├── CONTRIBUTING.md                  # Contribution guidelines
 ├── LICENSE                          # Apache License 2.0
 └── README.md                        # This file

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Standardized tool call formats that cascade into each other, eliminating duplica
 | Command | Purpose | Used By |
 |---------|---------|---------|
 | `/web` | Web search + URL reader via SearXNG MCP | Ask |
-| `/pdf` | PDF download via curl MCP | Ask |
+| `/pdf` | PDF download via curl MCP + read via pdf-reader-mcp | Ask |
 | `/git` | Git operations (MCP-first, CLI fallback) | Git |
 
 ### Delegation Commands (cascade to `/delegate`)

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ rm -f ~/.roo/mcp/pdf-curl-server.sh
 cp -rf skills/* ~/.roo/skills/
 cp -rf rules/git/* ~/.roo/rules-git/
 cp mcp/pdf-curl-server.sh ~/.roo/mcp/
+chmod +x ~/.roo/mcp/pdf-curl-server.sh
 ```
 
 To install a **specific version**, clone by tag instead:
@@ -237,6 +238,7 @@ rm -f ~/.roo/mcp/pdf-curl-server.sh
 cp -rf skills/* ~/.roo/skills/
 cp -rf rules/git/* ~/.roo/rules-git/
 cp mcp/pdf-curl-server.sh ~/.roo/mcp/
+chmod +x ~/.roo/mcp/pdf-curl-server.sh
 ```
 
 > **Why remove specific skills, not all?** The `rm -rf` targets only known RooForge skills (`caveman`, `conventional-commits`, `forge`, `grill-me`, `planning-and-task-breakdown`). This prevents accidental deletion of user-installed skills (e.g. via `npx skills add` or manual installs). If you add a new skill to this repo, **you must add it to the `rm -rf` line** in both install commands above.

--- a/agents/ask-export.yaml
+++ b/agents/ask-export.yaml
@@ -41,7 +41,8 @@ customModes:
 
       Flow: (1) Use codebase_search with query "memory" in .memory/ for
       existing cached intel. (2) For web research and reading URLs, use
-      run_slash_command with command 'web'. (3) Search the local codebase
+      run_slash_command with command 'web'. For PDFs and remote PDFs, use
+      run_slash_command with command 'pdf'. (3) Search the local codebase
       for patterns,
       configs, or constraints. (4) Follow information trails — if a result
       mentions a prerequisite, investigate immediately. (5) After gathering

--- a/commands/pdf.md
+++ b/commands/pdf.md
@@ -2,7 +2,8 @@
 name: pdf
 description: >
   PDF download via curl-download MCP and text extraction via pdf-reader-mcp.
-  Download PDFs from URLs, then read, search, or inspect them. Used by ask mode.
+  Download PDFs from URLs, then read, search, inspect, OCR, analyze regions,
+  extract regions, or render pages. Used by ask mode.
 ---
 
 # /pdf — PDF Download + Read via curl-download and pdf-reader-mcp
@@ -131,6 +132,91 @@ Two-step workflow: use `curl_download` to fetch PDF → use `pdf-reader-mcp` too
 - Good first step before deciding which `read_pdf` options to use.
 - Fast — does not extract full text by default.
 
+## OCR: `ocr_pages`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sources` | `array` | ✅ | — | Array of `{ path: string, url?: string }` objects. |
+| `pages` | `array` | ❌ | — | Page numbers to OCR (1-indexed). Omit for all pages. |
+| `language` | `string` | ❌ | `eng` | OCR language code (e.g., `eng`, `deu`, `fra`). |
+| `include_ocr_text_layer` | `boolean` | ❌ | `true` | Include normalized OCR text layer with render provenance. |
+| `max_output_chars` | `number` | ❌ | — | Max characters per page. |
+| `scale` | `number` | ❌ | `2` | Render scale for OCR. |
+| `timeout_ms` | `number` | ❌ | `30000` | Timeout per page in milliseconds. |
+
+### OCR Rules
+
+- Use `ocr_pages` on scanned or image-based PDFs where `read_pdf` returns little/no text.
+- Renders pages before OCR — slower than text extraction on native PDFs.
+- Specify `language` for non-English documents to improve accuracy.
+- Limit `pages` to avoid timeouts on large scanned documents.
+
+## Region Analysis: `analyze_regions`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sources` | `array` | ✅ | — | Array of `{ path: string, url?: string }` objects. |
+| `pages` | `array` | ❌ | — | Page numbers to analyze (1-indexed). Omit for all. |
+| `region_types` | `array` | ❌ | — | Types to detect: `table`, `image`, `formula`, `chart`, `figure`, `diagram`. |
+| `max_output_chars` | `number` | ❌ | — | Max chars per analyzed region. |
+| `scale` | `number` | ❌ | `2` | Render scale for visual analysis. |
+| `timeout_ms` | `number` | ❌ | `30000` | Timeout per region in ms. |
+| `include_image` | `boolean` | ❌ | `false` | Return cropped PNGs as MCP image parts. |
+
+### Region Analysis Rules
+
+- Use `analyze_regions` to identify tables, figures, and structured zones before extraction.
+- Specify `region_types` to narrow detection to relevant layout elements.
+- `include_image: true` returns visual crops of detected regions for verification.
+- Follow with `extract_regions` to pull specific bounding boxes.
+
+## Region Extraction: `extract_regions`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sources` | `array` | ✅ | — | Array of `{ path: string, url?: string }` objects with `regions` array. |
+| `pages` | `array` | ❌ | — | Page numbers to extract from (1-indexed). |
+| `regions` | `array` | ❌ | — | Array of `{ page, bounding_box: { left, top, right, bottom } }` objects. |
+| `max_output_chars` | `number` | ❌ | — | Max chars per extracted region. |
+| `scale` | `number` | ❌ | `2` | Render scale for extraction. |
+| `timeout_ms` | `number` | ❌ | `30000` | Timeout per region in ms. |
+| `include_image` | `boolean` | ❌ | `false` | Return cropped PNGs as MCP image parts. |
+
+### Region Extraction Rules
+
+- Use `extract_regions` after `analyze_regions` to pull specific content zones.
+- `regions` array defines bounding boxes in PDF coordinates (points, 1-indexed page).
+- Combine with `include_image: true` to get both text and visual evidence.
+- Useful for isolating tables, captions, or specific paragraphs from large pages.
+
+## Page Rendering: `render_page`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sources` | `array` | ✅ | — | Array of `{ path: string, url?: string }` objects. |
+| `pages` | `array` | ❌ | — | Page numbers to render (1-indexed). Omit for all. |
+| `format` | `string` | ❌ | `png` | Output format: `png` or `jpeg`. |
+| `dpi` | `number` | ❌ | `150` | Resolution in dots per inch. |
+| `max_pixels_per_page` | `number` | ❌ | `64000000` | Max pixels per rendered page. |
+| `max_pages` | `number` | ❌ | `20` | Max pages to render in one call. |
+| `scale` | `number` | ❌ | `2` | Render scale factor. |
+| `include_image` | `boolean` | ❌ | `true` | Return rendered pages as MCP image parts. |
+
+### Page Rendering Rules
+
+- Use `render_page` to produce visual previews of PDF pages for human review.
+- `dpi` controls quality — higher values produce sharper images but larger payloads.
+- `max_pages` caps at 20; paginate for larger documents.
+- Set `include_image: true` (default) to receive images directly in the response.
+
 ## Workflow
 
 1. Validate URL — must be `http(s)://*.pdf`
@@ -138,7 +224,10 @@ Two-step workflow: use `curl_download` to fetch PDF → use `pdf-reader-mcp` too
 3. Download — `curl -sfL --max-time 30` to `.memory/pdf-{timestamp}-{sanitized_basename}.pdf`
 4. **Inspect** — `inspect_pdf` on downloaded file for metadata + page count
 5. **Read/Search** — `read_pdf` for full extraction, or `search_pdf` for targeted term lookup
-6. Return extracted content for analysis
+6. **OCR** — `ocr_pages` if PDF is scanned/image-based and text extraction fails
+7. **Region Analysis** — `analyze_regions` to detect tables, figures, zones; then `extract_regions` to pull specific areas
+8. **Render** — `render_page` for visual preview of key pages
+9. Return extracted content for analysis
 
 ## Important
-Run `run_slash_command` ('pdf') once to load this context → use `curl_download` + `read_pdf` / `search_pdf` / `inspect_pdf` directly.
+Run `run_slash_command` ('pdf') once to load this context → use `curl_download` + `read_pdf` / `search_pdf` / `inspect_pdf` / `ocr_pages` / `analyze_regions` / `extract_regions` / `render_page` directly.

--- a/commands/pdf.md
+++ b/commands/pdf.md
@@ -2,8 +2,8 @@
 name: pdf
 description: >
   PDF download via curl-download MCP and text extraction via pdf-reader-mcp.
-  Download PDFs from URLs, then read, search, inspect, OCR, analyze regions,
-  extract regions, or render pages. Used by ask mode.
+  Download PDFs from URLs, then read, search, inspect, OCR, or extract regions.
+  Used by ask mode.
 ---
 
 # /pdf — PDF Download + Read via curl-download and pdf-reader-mcp
@@ -153,27 +153,6 @@ Two-step workflow: use `curl_download` to fetch PDF → use `pdf-reader-mcp` too
 - Specify `language` for non-English documents to improve accuracy.
 - Limit `pages` to avoid timeouts on large scanned documents.
 
-## Region Analysis: `analyze_regions`
-
-### Parameters
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `sources` | `array` | ✅ | — | Array of `{ path: string, url?: string }` objects. |
-| `pages` | `array` | ❌ | — | Page numbers to analyze (1-indexed). Omit for all. |
-| `region_types` | `array` | ❌ | — | Types to detect: `table`, `image`, `formula`, `chart`, `figure`, `diagram`. |
-| `max_output_chars` | `number` | ❌ | — | Max chars per analyzed region. |
-| `scale` | `number` | ❌ | `2` | Render scale for visual analysis. |
-| `timeout_ms` | `number` | ❌ | `30000` | Timeout per region in ms. |
-| `include_image` | `boolean` | ❌ | `false` | Return cropped PNGs as MCP image parts. |
-
-### Region Analysis Rules
-
-- Use `analyze_regions` to identify tables, figures, and structured zones before extraction.
-- Specify `region_types` to narrow detection to relevant layout elements.
-- `include_image: true` returns visual crops of detected regions for verification.
-- Follow with `extract_regions` to pull specific bounding boxes.
-
 ## Region Extraction: `extract_regions`
 
 ### Parameters
@@ -190,32 +169,10 @@ Two-step workflow: use `curl_download` to fetch PDF → use `pdf-reader-mcp` too
 
 ### Region Extraction Rules
 
-- Use `extract_regions` after `analyze_regions` to pull specific content zones.
+- Use `extract_regions` to pull specific content zones from known coordinates.
 - `regions` array defines bounding boxes in PDF coordinates (points, 1-indexed page).
 - Combine with `include_image: true` to get both text and visual evidence.
 - Useful for isolating tables, captions, or specific paragraphs from large pages.
-
-## Page Rendering: `render_page`
-
-### Parameters
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `sources` | `array` | ✅ | — | Array of `{ path: string, url?: string }` objects. |
-| `pages` | `array` | ❌ | — | Page numbers to render (1-indexed). Omit for all. |
-| `format` | `string` | ❌ | `png` | Output format: `png` or `jpeg`. |
-| `dpi` | `number` | ❌ | `150` | Resolution in dots per inch. |
-| `max_pixels_per_page` | `number` | ❌ | `64000000` | Max pixels per rendered page. |
-| `max_pages` | `number` | ❌ | `20` | Max pages to render in one call. |
-| `scale` | `number` | ❌ | `2` | Render scale factor. |
-| `include_image` | `boolean` | ❌ | `true` | Return rendered pages as MCP image parts. |
-
-### Page Rendering Rules
-
-- Use `render_page` to produce visual previews of PDF pages for human review.
-- `dpi` controls quality — higher values produce sharper images but larger payloads.
-- `max_pages` caps at 20; paginate for larger documents.
-- Set `include_image: true` (default) to receive images directly in the response.
 
 ## Workflow
 
@@ -225,9 +182,9 @@ Two-step workflow: use `curl_download` to fetch PDF → use `pdf-reader-mcp` too
 4. **Inspect** — `inspect_pdf` on downloaded file for metadata + page count
 5. **Read/Search** — `read_pdf` for full extraction, or `search_pdf` for targeted term lookup
 6. **OCR** — `ocr_pages` if PDF is scanned/image-based and text extraction fails
-7. **Region Analysis** — `analyze_regions` to detect tables, figures, zones; then `extract_regions` to pull specific areas
-8. **Render** — `render_page` for visual preview of key pages
-9. Return extracted content for analysis
+7. **Extract Regions** — `extract_regions` to pull specific areas from known coordinates
+8. Return extracted content for analysis
 
 ## Important
-Run `run_slash_command` ('pdf') once to load this context → use `curl_download` + `read_pdf` / `search_pdf` / `inspect_pdf` / `ocr_pages` / `analyze_regions` / `extract_regions` / `render_page` directly.
+
+Run `run_slash_command` ('pdf') once to load this context → use `curl_download` + `read_pdf` / `search_pdf` / `inspect_pdf` / `ocr_pages` / `extract_regions` directly.

--- a/commands/pdf.md
+++ b/commands/pdf.md
@@ -1,0 +1,43 @@
+---
+name: pdf
+description: >
+  PDF download via curl MCP. Download PDFs from URLs with URL validation
+  and Content-Type verification. Used by ask mode for PDF acquisition.
+---
+
+# /pdf — PDF Download via Curl MCP
+
+Single tool for downloading PDFs from URLs. Use `curl_download` to fetch → receive local path for downstream extraction.
+
+## Download: `curl_download`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `url` | `string` | ✅ | — | URL of the PDF to download. Must be HTTP(S) and end with `.pdf`. |
+
+### Download Rules
+
+- URL must be HTTP(S) and end with `.pdf`: `http://*.pdf` or `https://*.pdf`.
+- Content-Type verified before download: accepted types are `application/pdf`, `application/x-pdf`, `application/octet-stream`.
+- Downloaded file saved to `.memory/pdf-{timestamp}-{sanitized_basename}.pdf`.
+- Basename sanitization: `sed 's/[^a-zA-Z0-9._-]/_/g'`.
+
+### Error Handling
+
+| Condition | Response | Code |
+|-----------|----------|------|
+| Invalid URL (not HTTP(S) or not `.pdf`) | JSON-RPC error | `-32602` |
+| Non-PDF Content-Type | `isError: true` | — |
+| Download failure | `isError: true` | — |
+
+## Workflow
+
+1. Validate URL — must be `http(s)://*.pdf`
+2. Verify Content-Type — `curl -I` check for `application/pdf`, `application/x-pdf`, or `application/octet-stream`
+3. Download — `curl -sfL --max-time 30` to `.memory/pdf-{timestamp}-{sanitized_basename}.pdf`
+4. Return local path for downstream extraction (e.g., PDF reader MCP)
+
+## Important
+Run `run_slash_command` ('pdf') once to load this context → use `curl_download` directly.

--- a/commands/pdf.md
+++ b/commands/pdf.md
@@ -1,13 +1,13 @@
 ---
 name: pdf
 description: >
-  PDF download via curl MCP. Download PDFs from URLs with URL validation
-  and Content-Type verification. Used by ask mode for PDF acquisition.
+  PDF download via curl-download MCP and text extraction via pdf-reader-mcp.
+  Download PDFs from URLs, then read, search, or inspect them. Used by ask mode.
 ---
 
-# /pdf — PDF Download via Curl MCP
+# /pdf — PDF Download + Read via curl-download and pdf-reader-mcp
 
-Single tool for downloading PDFs from URLs. Use `curl_download` to fetch → receive local path for downstream extraction.
+Two-step workflow: use `curl_download` to fetch PDF → use `pdf-reader-mcp` tools to extract, search, or inspect.
 
 ## Download: `curl_download`
 
@@ -32,12 +32,113 @@ Single tool for downloading PDFs from URLs. Use `curl_download` to fetch → rec
 | Non-PDF Content-Type | `isError: true` | — |
 | Download failure | `isError: true` | — |
 
+## Read/Extract: `read_pdf`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sources` | `array` | ✅ | — | Array of `{ path: string, url?: string }` objects. PDF path(s) to read. |
+| `include_full_text` | `boolean` | ❌ | `false` | Extract full text from PDF. |
+| `include_markdown` | `boolean` | ❌ | `false` | Extract PDF as Markdown. |
+| `include_text_layer` | `boolean` | ❌ | `false` | Include text layer with run, line, word, character records. |
+| `include_metadata` | `boolean` | ❌ | `false` | Include PDF metadata and info objects. |
+| `include_outline` | `boolean` | ❌ | `false` | Include document outline/bookmark entries. |
+| `include_annotations` | `boolean` | ❌ | `false` | Include page annotations (links, notes). |
+| `include_tables` | `boolean` | ❌ | `false` | Detect and extract tables from PDF pages. |
+| `include_images` | `boolean` | ❌ | `false` | Extract embedded images as base64. |
+| `include_page_count` | `boolean` | ❌ | `false` | Include total number of pages. |
+| `include_page_geometry` | `boolean` | ❌ | `false` | Include page viewport geometry. |
+| `include_accessibility_report` | `boolean` | ❌ | `false` | Include accessibility report. |
+| `include_trust_report` | `boolean` | ❌ | `false` | Include trust report for safety findings. |
+| `include_layout_diagnostics` | `boolean` | ❌ | `false` | Include page layout profiles. |
+| `include_semantic_hints` | `boolean` | ❌ | `false` | Include semantic hints on text elements. |
+| `include_document_map` | `boolean` | ❌ | `false` | Include document map linking pages and elements. |
+| `include_document_ast` | `boolean` | ❌ | `false` | Include semantic document AST. |
+| `include_elements` | `boolean` | ❌ | `false` | Include structured document elements. |
+| `include_chunks` | `boolean` | ❌ | `false` | Include citation-ready chunks. |
+| `include_form_fields` | `boolean` | ❌ | `false` | Include PDF form field summaries. |
+| `include_ocr_text_layer` | `boolean` | ❌ | `false` | Run OCR on sparse/scanned pages and include text layer. |
+| `include_visual_enrichments` | `boolean` | ❌ | `false` | Fuse visual descriptions for tables, figures, charts. |
+| `include_structure_tree` | `boolean` | ❌ | `false` | Include tagged PDF structure trees. |
+| `include_safety_findings` | `boolean` | ❌ | `false` | Include safety findings (hidden/tiny/off-page text). |
+| `include_html` | `boolean` | ❌ | `false` | Include simple HTML rendering of extracted pages. |
+| `include_attachments` | `boolean` | ❌ | `false` | Include embedded attachment metadata. |
+| `include_page_labels` | `boolean` | ❌ | `false` | Include PDF page labels. |
+| `include_permissions` | `boolean` | ❌ | `false` | Include PDF permission and marking signals. |
+| `maxLength` | `number` | ❌ | — | Max output characters to return (per page). |
+| `sample_pages` | `number` | ❌ | `5` | Max pages to sample when auto-inspection enabled. |
+| `max_visual_enrichments` | `number` | ❌ | — | Max visual regions per source. |
+| `trust_report_redaction` | `string` | ❌ | `standard` | Redaction policy: `standard`, `strict`, `off`. |
+| `auto` | `boolean` | ❌ | `true` | Auto-inspect each source and choose extraction options. |
+| `auto_detail` | `string` | ❌ | `balanced` | Auto extraction depth: `fast`, `balanced`, `full`. |
+
+### Read/Extract Rules
+
+- Always pass downloaded PDF path as `sources` array with `path` field.
+- Use `auto: true` (default) to let the server choose extraction options — good for first-pass analysis.
+- Use explicit `include_*` flags when you need specific outputs (e.g., `include_markdown: true` for RAG, `include_full_text: true` for text extraction).
+- Limit output with `maxLength` to avoid token overflow on large PDFs.
+- `include_ocr_text_layer` is useful for scanned PDFs.
+
+## Search: `search_pdf`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | `string` | ✅ | — | Literal text query to search for in PDF text. |
+| `sources` | `array` | ✅ | — | Array of `{ path: string, url?: string }` objects. |
+| `case_sensitive` | `boolean` | ❌ | `false` | Case-sensitive literal matching. |
+| `whole_word` | `boolean` | ❌ | `false` | Match only whole words using ASCII boundaries. |
+| `max_matches_per_source` | `number` | ❌ | `50` | Max matches per source (capped at 500). |
+| `max_pages` | `number` | ❌ | `100` | Max pages to search per source. |
+| `context_chars` | `number` | ❌ | `120` | Context characters around each match. |
+| `include_ocr_text_layer` | `boolean` | ❌ | `false` | Also search OCR text layer (renders pages). |
+
+### Search Rules
+
+- Use `search_pdf` after `read_pdf` to locate specific terms within a known PDF.
+- `query` is literal text — not regex.
+- Increase `context_chars` when you need more surrounding text per match.
+- `include_ocr_text_layer` may be slow on large scanned PDFs.
+
+## Inspect: `inspect_pdf`
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sources` | `array` | ✅ | — | Array of `{ path: string, url?: string }` objects. |
+| `include_metadata` | `boolean` | ❌ | `false` | Include PDF metadata. |
+| `include_page_count` | `boolean` | ❌ | `false` | Include total page count. |
+| `include_attachments` | `boolean` | ❌ | `false` | Include embedded attachment metadata. |
+| `include_form_fields` | `boolean` | ❌ | `false` | Include AcroForm field summaries. |
+| `include_permissions` | `boolean` | ❌ | `false` | Include permission and marking signals. |
+| `include_page_labels` | `boolean` | ❌ | `false` | Include page labels. |
+| `include_annotations` | `boolean` | ❌ | `false` | Include annotations. |
+| `include_layout_diagnostics` | `boolean` | ❌ | `false` | Include layout diagnostics. |
+| `include_safety_findings` | `boolean` | ❌ | `false` | Include safety findings. |
+| `include_trust_report` | `boolean` | ❌ | `false` | Include trust report. |
+| `include_accessibility_report` | `boolean` | ❌ | `false` | Include accessibility report. |
+| `include_page_geometry` | `boolean` | ❌ | `false` | Include page geometry. |
+| `maxLength` | `number` | ❌ | — | Max output characters. |
+| `sample_pages` | `number` | ❌ | `5` | Max pages to sample for inspection. |
+
+### Inspect Rules
+
+- Use `inspect_pdf` for quick overview: page count, metadata, structure, safety findings.
+- Good first step before deciding which `read_pdf` options to use.
+- Fast — does not extract full text by default.
+
 ## Workflow
 
 1. Validate URL — must be `http(s)://*.pdf`
 2. Verify Content-Type — `curl -I` check for `application/pdf`, `application/x-pdf`, or `application/octet-stream`
 3. Download — `curl -sfL --max-time 30` to `.memory/pdf-{timestamp}-{sanitized_basename}.pdf`
-4. Return local path for downstream extraction (e.g., PDF reader MCP)
+4. **Inspect** — `inspect_pdf` on downloaded file for metadata + page count
+5. **Read/Search** — `read_pdf` for full extraction, or `search_pdf` for targeted term lookup
+6. Return extracted content for analysis
 
 ## Important
-Run `run_slash_command` ('pdf') once to load this context → use `curl_download` directly.
+Run `run_slash_command` ('pdf') once to load this context → use `curl_download` + `read_pdf` / `search_pdf` / `inspect_pdf` directly.

--- a/commands/research.md
+++ b/commands/research.md
@@ -29,6 +29,7 @@ Where to look first:
 - `codebase` — search local repo for patterns, configs, existing implementations
 - `web` — search external docs, APIs, library docs
 - `.memory/` — check working memory for previously cached intel
+- If research requires reading a PDF document, use `/pdf` command to download and extract it before analysis
 - Order matters: list sources in priority sequence
 
 ### Expected answer format

--- a/commands/web.md
+++ b/commands/web.md
@@ -47,6 +47,7 @@ Two tools for web intel gathering. Use `searxng_web_search` to find → `web_url
 - Use `readHeadings: true` first to scan structure → then `section` or `paragraphRange` to extract relevant parts.
 - Use `maxLength` to limit output — avoid pulling entire pages when only section needed.
 - URL fails → skip it, try next search result.
+- If a search result URL points to a `.pdf` file, use `/pdf` command instead of `web_url_read` to download and extract it.
 
 ## Workflow
 

--- a/mcp.md
+++ b/mcp.md
@@ -38,7 +38,7 @@ The Forge pipeline requires three MCP servers for full functionality. Add the en
     "pdf-reader-mcp": {
       "command": "npx",
       "args": ["-y", "@sylphx/pdf-reader-mcp"],
-      "alwaysAllow": ["read_pdf", "search_pdf", "inspect_pdf"]
+      "alwaysAllow": ["read_pdf", "search_pdf", "inspect_pdf", "ocr_pages", "analyze_regions", "extract_regions", "render_page"]
     },
     "git-mcp-server": {
       "command": "npx",
@@ -170,6 +170,10 @@ Ask mode uses [`@sylphx/pdf-reader-mcp`](https://www.npmjs.com/package/@sylphx/p
 | `read_pdf` | Extract full text or Markdown from a PDF | `sources`, `include_full_text`, `include_markdown`, `maxLength` |
 | `search_pdf` | Search for specific terms within a PDF | `query`, `sources`, `case_sensitive`, `max_matches_per_source` |
 | `inspect_pdf` | Get metadata and structure overview | `sources` |
+| `ocr_pages` | OCR text from scanned/image pages | `sources`, `pages`, `language`, `include_ocr_text_layer` |
+| `analyze_regions` | Analyze document layout regions | `sources`, `pages`, `region_types`, `include_image` |
+| `extract_regions` | Extract specific regions from pages | `sources`, `pages`, `regions`, `include_image` |
+| `render_page` | Render page as image or preview | `sources`, `pages`, `format`, `dpi`, `include_image` |
 
 ### Setup
 

--- a/mcp.md
+++ b/mcp.md
@@ -6,9 +6,10 @@
 
 [![SearXNG](https://img.shields.io/badge/SearXNG-Ask%20Mode-blue)](#searxng)
 [![Curl Download](https://img.shields.io/badge/Curl%20Download-Ask%20Mode-green)](#curl-download-mcp)
+[![PDF Reader](https://img.shields.io/badge/PDF%20Reader-Ask%20Mode-purple)](#pdf-reader-mcp)
 [![Git MCP](https://img.shields.io/badge/Git%20MCP-Git%20Mode-orange)](#git-mcp-server)
 
-*Privacy-respecting search · PDF download · Structured git access · MCP-first*
+*Privacy-respecting search · PDF download · PDF text extraction · Structured git access · MCP-first*
 
 </div>
 
@@ -31,8 +32,13 @@ The Forge pipeline requires three MCP servers for full functionality. Add the en
     },
     "curl-download": {
       "command": "sh",
-      "args": ["mcp/pdf-curl-server.sh"],
+      "args": ["~/.roo/mcp/pdf-curl-server.sh"],
       "alwaysAllow": ["curl_download"]
+    },
+    "pdf-reader-mcp": {
+      "command": "npx",
+      "args": ["-y", "@sylphx/pdf-reader-mcp"],
+      "alwaysAllow": ["read_pdf", "search_pdf", "inspect_pdf"]
     },
     "git-mcp-server": {
       "command": "npx",
@@ -127,10 +133,12 @@ Ask mode uses the repo-owned `curl-download` MCP server for downloading PDFs fro
 
 ### Setup
 
-**Step 1:** Make the server script executable:
+**Step 1:** Create the MCP directory and make the server script executable:
 
 ```bash
+mkdir -p ~/.roo/mcp
 chmod +x mcp/pdf-curl-server.sh
+cp mcp/pdf-curl-server.sh ~/.roo/mcp/
 ```
 
 **Step 2:** Ensure dependencies are installed. The script requires `curl` and either `jq` or `python3`:
@@ -147,6 +155,25 @@ python3 --version
 ```
 
 **Step 3:** The MCP config block above connects Zoo Code to the curl-download server. Restart Zoo Code → switch to Ask mode → run `curl_download` → confirm PDF is downloaded to `.memory/`.
+
+---
+
+## PDF Reader MCP
+
+**Required by:** Ask mode
+**Purpose:** Extract and parse text from downloaded PDFs
+
+Ask mode uses [`@sylphx/pdf-reader-mcp`](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp) for reading and extracting structured text from PDF files after they have been downloaded by the `curl-download` server.
+
+| Tool | Purpose | Key Parameters |
+|------|---------|--------------|
+| `read_pdf` | Extract full text or Markdown from a PDF | `sources`, `include_full_text`, `include_markdown`, `maxLength` |
+| `search_pdf` | Search for specific terms within a PDF | `query`, `sources`, `case_sensitive`, `max_matches_per_source` |
+| `inspect_pdf` | Get metadata and structure overview | `sources` |
+
+### Setup
+
+The MCP config block above connects Zoo Code to the PDF reader server. No additional setup required — `npx` handles the installation automatically.
 
 ---
 
@@ -211,14 +238,14 @@ The orchestration pipeline commits locally but does not auto-push. Push is destr
 
 ## Impact on the Pipeline
 
-| Mode | SearXNG | Curl Download MCP | Git MCP |
-|------|---------|-------------------|---------|
-| **Orchestrator** | Indirect (via Ask) | — | Indirect (via Git) |
-| **Ask** | **Direct** | **Direct** | — |
-| **Architect** | Indirect (via Ask) | — | — |
-| **Subtask Orchestrator** | Indirect (via Ask) | — | Indirect (via Git) |
-| **Code** | — | — | — |
-| **Git** | — | — | **Direct** |
+| Mode | SearXNG | Curl Download MCP | PDF Reader MCP | Git MCP |
+|------|---------|-------------------|----------------|---------|
+| **Orchestrator** | Indirect (via Ask) | — | — | Indirect (via Git) |
+| **Ask** | **Direct** | **Direct** | **Direct** | — |
+| **Architect** | Indirect (via Ask) | — | — | — |
+| **Subtask Orchestrator** | Indirect (via Ask) | — | — | Indirect (via Git) |
+| **Code** | — | — | — | — |
+| **Git** | — | — | — | **Direct** |
 
 ---
 

--- a/mcp.md
+++ b/mcp.md
@@ -32,7 +32,7 @@ The Forge pipeline requires three MCP servers for full functionality. Add the en
     },
     "curl-download": {
       "command": "sh",
-      "args": ["~/.roo/mcp/pdf-curl-server.sh"],
+      "args": ["-c", "exec ~/.roo/mcp/pdf-curl-server.sh"],
       "alwaysAllow": ["curl_download"]
     },
     "pdf-reader-mcp": {

--- a/mcp.md
+++ b/mcp.md
@@ -5,9 +5,10 @@
 **Model Context Protocol servers for the Forge pipeline**
 
 [![SearXNG](https://img.shields.io/badge/SearXNG-Ask%20Mode-blue)](#searxng)
+[![Curl Download](https://img.shields.io/badge/Curl%20Download-Ask%20Mode-green)](#curl-download-mcp)
 [![Git MCP](https://img.shields.io/badge/Git%20MCP-Git%20Mode-orange)](#git-mcp-server)
 
-*Privacy-respecting search · Structured git access · MCP-first*
+*Privacy-respecting search · PDF download · Structured git access · MCP-first*
 
 </div>
 
@@ -15,7 +16,7 @@
 
 ## Overview
 
-The Forge pipeline requires two MCP servers for full functionality. Add the entire block below to your Zoo Code MCP settings using the MCP settings view (**Edit Global MCP**). If editing manually, use the global `mcp_settings.json` file for your Zoo Code extension ID (`ZooCodeOrganization.zoo-code`).
+The Forge pipeline requires three MCP servers for full functionality. Add the entire block below to your Zoo Code MCP settings using the MCP settings view (**Edit Global MCP**). If editing manually, use the global `mcp_settings.json` file for your Zoo Code extension ID (`ZooCodeOrganization.zoo-code`).
 
 ```json
 {
@@ -27,6 +28,11 @@ The Forge pipeline requires two MCP servers for full functionality. Add the enti
         "SEARXNG_URL": "http://localhost:8088/"
       },
       "alwaysAllow": ["web_url_read", "searxng_web_search"]
+    },
+    "curl-download": {
+      "command": "sh",
+      "args": ["mcp/pdf-curl-server.sh"],
+      "alwaysAllow": ["curl_download"]
     },
     "git-mcp-server": {
       "command": "npx",
@@ -108,6 +114,42 @@ By default, Zoo Code asks for confirmation before each MCP tool call. Adding too
 
 ---
 
+## Curl Download MCP
+
+**Required by:** Ask mode
+**Purpose:** Download PDFs from URLs via POSIX shell + curl
+
+Ask mode uses the repo-owned `curl-download` MCP server for downloading PDFs from URLs. No `npx` or npm dependency — the server runs directly via `sh` with a POSIX shell script.
+
+| Tool | Purpose | Key Parameters |
+|------|---------|--------------|
+| `curl_download` | Download PDF from URL to `.memory/` | `url` (string, required) |
+
+### Setup
+
+**Step 1:** Make the server script executable:
+
+```bash
+chmod +x mcp/pdf-curl-server.sh
+```
+
+**Step 2:** Ensure dependencies are installed. The script requires `curl` and either `jq` or `python3`:
+
+```bash
+# Check curl
+curl --version
+
+# Check jq (preferred)
+jq --version
+
+# Or check python3 (fallback)
+python3 --version
+```
+
+**Step 3:** The MCP config block above connects Zoo Code to the curl-download server. Restart Zoo Code → switch to Ask mode → run `curl_download` → confirm PDF is downloaded to `.memory/`.
+
+---
+
 ## Git MCP Server
 
 **Required by:** Git mode
@@ -169,14 +211,14 @@ The orchestration pipeline commits locally but does not auto-push. Push is destr
 
 ## Impact on the Pipeline
 
-| Mode | SearXNG | Git MCP |
-|------|---------|---------|
-| **Orchestrator** | Indirect (via Ask) | Indirect (via Git) |
-| **Ask** | **Direct** | — |
-| **Architect** | Indirect (via Ask) | — |
-| **Subtask Orchestrator** | Indirect (via Ask) | Indirect (via Git) |
-| **Code** | — | — |
-| **Git** | — | **Direct** |
+| Mode | SearXNG | Curl Download MCP | Git MCP |
+|------|---------|-------------------|---------|
+| **Orchestrator** | Indirect (via Ask) | — | Indirect (via Git) |
+| **Ask** | **Direct** | **Direct** | — |
+| **Architect** | Indirect (via Ask) | — | — |
+| **Subtask Orchestrator** | Indirect (via Ask) | — | Indirect (via Git) |
+| **Code** | — | — | — |
+| **Git** | — | — | **Direct** |
 
 ---
 

--- a/mcp/pdf-curl-server.sh
+++ b/mcp/pdf-curl-server.sh
@@ -2,8 +2,6 @@
 # MCP stdio server for PDF curl downloads
 # POSIX sh, auto-detects jq or python3 for JSON parsing
 
-set -e
-
 # ---- JSON parser detection ----
 JSON_TOOL=""
 if command -v jq >/dev/null 2>&1; then
@@ -20,9 +18,9 @@ _json_get() {
     _key="$1"
     _json="$2"
     if [ "$JSON_TOOL" = "jq" ]; then
-        printf '%s' "$_json" | jq -r --arg k "$_key" '.[$k] // empty'
+        printf '%s' "$_json" | jq -r --arg k "$_key" '.[$k] // empty' || true
     else
-        printf '%s' "$_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$_key','') if isinstance(d,dict) else '')"
+        printf '%s' "$_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$_key','') if isinstance(d,dict) else '')" 2>/dev/null || true
     fi
 }
 
@@ -30,9 +28,9 @@ _json_get_nested() {
     _path="$1"
     _json="$2"
     if [ "$JSON_TOOL" = "jq" ]; then
-        printf '%s' "$_json" | jq -r --arg p "$_path" 'reduce ($p | split("."))[] as $k (.; .[$k]) // empty'
+        printf '%s' "$_json" | jq -r --arg p "$_path" 'reduce ($p | split("."))[] as $k (.; .[$k]) // empty' || true
     else
-        printf '%s' "$_json" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d; [v:=v.get(k) if isinstance(v,dict) else None for k in '$_path'.split('.')]; print(v if v is not None else '')"
+        printf '%s' "$_json" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d; [v:=v.get(k) if isinstance(v,dict) else None for k in '$_path'.split('.')]; print(v if v is not None else '')" 2>/dev/null || true
     fi
 }
 

--- a/mcp/pdf-curl-server.sh
+++ b/mcp/pdf-curl-server.sh
@@ -57,7 +57,8 @@ validate_url() {
 }
 
 is_pdf_content_type() {
-    case "$1" in
+    _ct="${1%%;*}"
+    case "$_ct" in
         application/pdf|application/x-pdf|application/octet-stream) return 0 ;;
         *) return 1 ;;
     esac

--- a/mcp/pdf-curl-server.sh
+++ b/mcp/pdf-curl-server.sh
@@ -1,0 +1,183 @@
+#!/bin/sh
+# MCP stdio server for PDF curl downloads
+# POSIX sh, auto-detects jq or python3 for JSON parsing
+
+set -e
+
+# ---- JSON parser detection ----
+JSON_TOOL=""
+if command -v jq >/dev/null 2>&1; then
+    JSON_TOOL="jq"
+elif command -v python3 >/dev/null 2>&1; then
+    JSON_TOOL="python3"
+else
+    echo '{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"No JSON parser available"}}' >&2
+    exit 1
+fi
+
+# ---- JSON helpers ----
+_json_get() {
+    _key="$1"
+    _json="$2"
+    if [ "$JSON_TOOL" = "jq" ]; then
+        printf '%s' "$_json" | jq -r --arg k "$_key" '.[$k] // empty'
+    else
+        printf '%s' "$_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$_key','') if isinstance(d,dict) else '')"
+    fi
+}
+
+_json_get_nested() {
+    _path="$1"
+    _json="$2"
+    if [ "$JSON_TOOL" = "jq" ]; then
+        printf '%s' "$_json" | jq -r --arg p "$_path" 'reduce ($p | split("."))[] as $k (.; .[$k]) // empty'
+    else
+        printf '%s' "$_json" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d; [v:=v.get(k) if isinstance(v,dict) else None for k in '$_path'.split('.')]; print(v if v is not None else '')"
+    fi
+}
+
+# ---- Response helpers ----
+send_result() {
+    _id="$1"
+    _result="$2"
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$_id,\"result\":$_result}"
+}
+
+send_error() {
+    _id="$1"
+    _code="$2"
+    _message="$3"
+    printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":$_id,\"error\":{\"code\":$_code,\"message\":\"$_message\"}}"
+}
+
+# ---- Tool: curl_download ----
+validate_url() {
+    case "$1" in
+        https://*.pdf|http://*.pdf) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_pdf_content_type() {
+    case "$1" in
+        application/pdf|application/x-pdf|application/octet-stream) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+handle_curl_download() {
+    _url="$1"
+    _id="$2"
+
+    if ! validate_url "$_url"; then
+        send_error "$_id" -32602 "Invalid URL: must be http(s)://*.pdf"
+        return
+    fi
+
+    _content_type=$(curl -s -o /dev/null -L --max-time 10 -w '%{content_type}' "$_url")
+    if ! is_pdf_content_type "$_content_type"; then
+        send_error "$_id" -32602 "Invalid Content-Type: $_content_type (expected application/pdf, application/x-pdf, or application/octet-stream)"
+        return
+    fi
+
+    _basename=$(basename "$_url" | sed 's/[^a-zA-Z0-9._-]/_/g')
+    _timestamp=$(date +%s)
+    _output_path=".memory/pdf-${_timestamp}-${_basename}"
+
+    mkdir -p .memory
+
+    if ! curl -sfL --max-time 30 -o "$_output_path" "$_url" 2>/dev/null; then
+        send_error "$_id" -32602 "Download failed for $_url"
+        return
+    fi
+
+    _result="{\"content\":[{\"type\":\"text\",\"text\":\"Downloaded PDF to $_output_path (Content-Type: $_content_type)\"}],\"isError\":false}"
+    send_result "$_id" "$_result"
+}
+
+# ---- Handlers ----
+handle_initialize() {
+    _id="$1"
+    _result='{"protocolVersion":"2025-03-26","capabilities":{"experimental":{},"prompts":{"listChanged":false},"resources":{"subscribe":false,"listChanged":false},"tools":{"listChanged":false}},"serverInfo":{"name":"curl-download-server","version":"1.0.0"}}'
+    send_result "$_id" "$_result"
+}
+
+handle_initialized() {
+    # notification, no response
+    :
+}
+
+handle_ping() {
+    _id="$1"
+    _result='{}'
+    send_result "$_id" "$_result"
+}
+
+handle_tools_list() {
+    _id="$1"
+    _result='{"tools":[{"name":"curl_download","description":"Download a PDF from a URL after validating the URL and Content-Type","inputSchema":{"type":"object","properties":{"url":{"type":"string","description":"URL of the PDF to download (must end with .pdf)"}},"required":["url"]}}]}'
+    send_result "$_id" "$_result"
+}
+
+handle_tools_call() {
+    _id="$1"
+    _params="$2"
+
+    _name="$(_json_get_nested 'params.name' "$_params")"
+    if [ -z "$_name" ]; then
+        _name="$(_json_get 'name' "$_params")"
+    fi
+
+    if [ "$JSON_TOOL" = "jq" ]; then
+        _url="$(printf '%s' "$_params" | jq -r '.params.arguments.url // .arguments.url // empty')"
+    else
+        _url="$(printf '%s' "$_params" | python3 -c "import sys,json; d=json.load(sys.stdin); a=d.get('params',{}).get('arguments',{}) if isinstance(d.get('params'),dict) else d.get('arguments',{}); print(a.get('url',''))")"
+    fi
+
+    if [ "$_name" != "curl_download" ]; then
+        send_error "$_id" -32602 "Unknown tool: $_name"
+        return
+    fi
+
+    if [ -z "$_url" ]; then
+        send_error "$_id" -32602 "Missing required argument: url"
+        return
+    fi
+
+    handle_curl_download "$_url" "$_id"
+}
+
+# ---- Main loop ----
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+
+    _method="$(_json_get 'method' "$line")"
+    _id_raw="$(_json_get 'id' "$line")"
+    _id="$_id_raw"
+    if [ -z "$_id" ]; then
+        _id="null"
+    fi
+
+    case "$_method" in
+        initialize)
+            handle_initialize "$_id"
+            ;;
+        notifications/initialized)
+            handle_initialized
+            ;;
+        ping)
+            handle_ping "$_id"
+            ;;
+        tools/list)
+            handle_tools_list "$_id"
+            ;;
+        tools/call)
+            handle_tools_call "$_id" "$line"
+            ;;
+        *)
+            if [ "$_id" != "null" ]; then
+                send_error "$_id" -32601 "Method not found: $_method"
+            fi
+            ;;
+    esac
+done

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -84,6 +84,7 @@ All commands run via `run_slash_command` with command name as `command` paramete
 | Command | Purpose | Used By | Mandatory Skills |
 |---------|---------|---------|-----------------|
 | `/web` | Web search + URL reader via SearXNG MCP | `ask` | — |
+| `/pdf` | PDF download via curl-download MCP + read via pdf-reader-mcp | `ask` | — |
 | `/git` | Git operations (MCP-first, CLI fallback) | `git` | **conventional-commits** |
 
 ### Delegation Commands (cascade to /delegate)
@@ -109,6 +110,7 @@ Commands reference each other to avoid duplication:
 - `/forge-init` → runs `/delegate` with mode `code`
 - `/finalize` → formats `attempt_completion` for human consumption (no cascade)
 - `/web` → direct MCP tool calls (no cascade)
+- `/pdf` → direct MCP tool calls via curl-download + pdf-reader-mcp (no cascade)
 - `/git` → MCP-first, CLI fallback with branch setup (no cascade)
 
 ## Conventions


### PR DESCRIPTION
# Closes #20 — feat(ask): integrate PDF curl MCP server for PDF downloading and parsing

## What This PR Does

This PR adds a complete PDF acquisition and parsing pipeline to the Forge orchestration system, enabling the `ask` mode to download remote PDFs and extract structured text from them.

## Changes Summary

### New Files

- **`mcp/pdf-curl-server.sh`** — POSIX shell MCP stdio server implementing JSON-RPC 2.0 over stdin/stdout with a `curl_download` tool. Validates URLs (HTTP(S) + `.pdf`), verifies Content-Type before download, strips semicolon parameters, and caches files to `.memory/`. `jq` preferred, `python3` fallback. No npm dependencies.
- **`commands/pdf.md`** — `/pdf` slash command documenting the full PDF workflow: `curl_download` (download) + `read_pdf`, `search_pdf`, `inspect_pdf`, `ocr_pages`, `extract_regions` (extract).

### Added MCP Server: `curl-download`

A **repo-owned, POSIX shell-based MCP server** (`mcp/pdf-curl-server.sh`) that requires zero external npm dependencies. It runs directly via `sh` and communicates with Zoo Code via JSON-RPC 2.0 over stdio.

**JSON-RPC Methods Implemented:**
- `initialize` — returns protocol version, capabilities, and server info
- `notifications/initialized` — silent acknowledgment (no response)
- `ping` — health check returning empty result `{}`
- `tools/list` — exposes `curl_download` tool schema
- `tools/call` — executes `curl_download` with URL validation and Content-Type verification

**Tool: `curl_download`**
- Validates URL format (`http(s)://*.pdf`) via POSIX `case` statement
- Verifies Content-Type via `curl -I` before downloading
- Accepts `application/pdf`, `application/x-pdf`, `application/octet-stream` (with semicolon parameter stripping via `_ct="${1%%;*}"`)
- Downloads via `curl -sfL` to `.memory/pdf-{timestamp}-{sanitized_basename}.pdf`
- Returns MCP-compliant `content` array with `isError` boolean
- Auto-detects `jq` (preferred) or `python3` for JSON parsing; exits with `-32603` if neither is available

**Installation:**
```bash
mkdir -p ~/.roo/mcp
cp mcp/pdf-curl-server.sh ~/.roo/mcp/
chmod +x ~/.roo/mcp/pdf-curl-server.sh
```

**MCP Config:**
```json
"curl-download": {
  "command": "sh",
  "args": ["-c", "exec ~/.roo/mcp/pdf-curl-server.sh"],
  "alwaysAllow": ["curl_download"]
}
```

### Added MCP Server: `pdf-reader-mcp`

An **npm-based MCP server** (`@sylphx/pdf-reader-mcp`) installed automatically via `npx -y`. It enables the `ask` mode to read and extract structured text from PDF files after they have been downloaded by the `curl-download` server.

**Tools:**
- `read_pdf` — Extract full text or Markdown from a PDF
- `search_pdf` — Search for specific terms within a PDF
- `inspect_pdf` — Get metadata and structure overview
- `ocr_pages` — OCR text from scanned/image pages
- `analyze_regions` — Analyze document layout regions
- `extract_regions` — Extract specific regions from pages
- `render_page` — Render page as image or preview

**MCP Config:**
```json
"pdf-reader-mcp": {
  "command": "npx",
  "args": ["-y", "@sylphx/pdf-reader-mcp"],
  "alwaysAllow": ["read_pdf", "search_pdf", "inspect_pdf", "ocr_pages", "analyze_regions", "extract_regions", "render_page"]
}
```

### Modified Files

- **`.github/workflows/release.yml`** — added `mcp/**` to release trigger paths, added `mcp.zip` to release archives and release body, updated install instructions to include `mcp.zip` extraction.
- **`mcp.md`** — registered `curl-download` MCP server (`~/.roo/mcp/pdf-curl-server.sh`) and `pdf-reader-mcp` npm server (`@sylphx/pdf-reader-mcp`). Full tool tables for all 7 pdf-reader-mcp tools. Updated impact table.
- **`agents/ask-export.yaml`** — step 2 now mentions both "PDFs and remote PDFs" and the `/pdf` command alongside `/web`.
- **`README.md`** — synced with `/pdf`, MCP servers, `~/.roo/mcp/` install commands (with `chmod +x`), `mcp/` in repo structure.
- **`AGENTS.md`** — synced command registry, MCP servers, key docs, mode capabilities.
- **`skills/forge/SKILL.md`** — `/pdf` registered in Tool Commands and Cascading Behavior tables.
- **`commands/web.md`** — Read Rules mention using `/pdf` for PDF URLs.
- **`commands/research.md`** — Source Priority mentions using `/pdf` for PDF documents.

## Key Fixes Applied During Development

1. **Removed `set -e`** from `mcp/pdf-curl-server.sh` — killed the long-running stdio server on any non-zero curl/jq/python3 exit.
2. **Hardened JSON helpers** — `|| true` / `2>/dev/null || true` so parse failures return empty instead of crashing.
3. **Fixed MCP config path** — `sh -c "exec ~/.roo/mcp/pdf-curl-server.sh"` so `~` expands correctly (Node.js `child_process.spawn` does not expand `~`).
4. **Fixed Content-Type parsing** — `_ct="${1%%;*}"` strips semicolon parameters (`application/pdf; qs=0.001` → `application/pdf`) before MIME check.
5. **Added `chmod +x`** — ensures `pdf-curl-server.sh` is executable after `cp` to `~/.roo/mcp/`.

## Live Test Results

| URL | Content-Type | Status |
|-----|--------------|--------|
| `https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf` | `application/pdf; qs=0.001` | ✅ PASS |
| `https://www.pdf995.com/samples/pdf.pdf` | `application/pdf` | ✅ PASS |
| `https://s21.q4cdn.com/676487211/files/doc_downloads/test.pdf` | `application/pdf` | ✅ PASS |

- `render_page` tested — returned PNG image (1224×1584), confirming `pdf-reader-mcp` works.
- `ocr_pages` and `analyze_regions` tested — respond correctly (require external provider config, expected behavior).

## Commit History (clean, conventional commits)

| Commit | Type | Message |
|--------|------|---------|
| `27c3621` | `feat` | integrate PDF curl MCP server for PDF downloading and parsing via ask mode |
| `2f6160c` | `feat` | add pdf-reader-mcp server support |
| `ef1ec83` | `fix` | resolve MCP connection closed errors from set -e and ~ path expansion |
| `a04bac0` | `fix` | strip Content-Type parameters before MIME check in is_pdf_content_type() |
| `870b2d6` | `feat` | document pdf-reader-mcp read, search, and inspect tools |
| `ed10260` | `feat` | add four missing pdf-reader-mcp tools to docs |
| `fce09b8` | `fix` | remove render_page and analyze_regions from pdf command docs |
| `ad86420` | `fix` | add chmod +x after pdf-curl-server.sh copy in install commands |
| `40c9eac` | `feat` | add mcp.zip to release workflow and include mcp/** trigger |

## How to Test

1. Run the install commands from `README.md` — they copy `mcp/pdf-curl-server.sh` to `~/.roo/mcp/` and `chmod +x` it.
2. Add the MCP config block from `mcp.md` to Zoo Code MCP settings (`Edit Global MCP`).
3. Switch to Ask mode → provide a PDF URL → `/pdf` downloads it to `.memory/` → `pdf-reader-mcp` parses it.

## Checklist

- [x] Tested in isolation (ask mode imports correctly)
- [x] Tested within the full pipeline (all modes active)
- [x] Verified no regression in other modes
- [x] `README.md` and `AGENTS.md` stay in sync per Documentation Sync Rule
- [x] All commits follow Conventional Commits format
- [x] Branch name follows `feat/<desc>` convention