### PR TITLE
fix(ci): trigger release workflow on .github/ changes too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "skills/**"
       - "mcp/**"
+      - ".github/**"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Why

After merging #25 the release run never fired: the path filter only watched `skills/**` and `mcp/**`, and both commits on that PR only touched `.github/workflows/release.yml`. Pure `ci:` commits therefore never produce a release.

## What

Add `.github/**` to the `push.paths` filter so workflow changes themselves trigger `Auto Version & Release` like any other push.

## After merge

Merge via the GitHub UI. The next push to `main` touching `skills/`, `mcp/`, or `.github/` will run the workflow. Note: the merge of **this** PR is itself a `.github/` change, so it will trigger the run immediately — and since the `feat(ci)!` breaking commit from #25 is already on `main`'s history since the last tag, the semantic tag action should emit a **major** bump on that run.