### PR TITLE
Add validate.sh post-pass safety check to loops

### DIFF
--- a/docs/guides/loops.md
+++ b/docs/guides/loops.md
@@ -13,7 +13,7 @@ A shell framework that drives `kimi -p` review/resolve loops. The calling skill 
 
 1. **Caller provides prompt template** — the calling skill owns a `.md` template under its own `templates/` (e.g. `pr-review/templates/review-loop.md`). The template must include: mandatory first skill loads, no-plan-mode instruction, and the `DONE:`/`BLOCKED:` contract line, plus broader context (why this task exists, where it fits) and task context (exact paths, commands, output format) per the caller contract (`skills/loops/SKILL.md:35-42`).
 
-2. **Render & compress** — `run_loop.sh` changes to `[workdir]`, then pipes the template through `cavemanize.sh` (removes filler words, collapses whitespace, preserves code blocks) to produce `.loops/<name>/prompt.rendered.md` (`scripts/run_loop.sh:18-23`).
+2. **Render & compress** — `run_loop.sh` changes to `[workdir]`, then pipes the template through `cavemanize.sh` (removes filler words, collapses whitespace, preserves code blocks) to produce `.loops/<name>/prompt.rendered.md` (`scripts/run_loop.sh:18-23`). `validate.sh` then compares the template against the rendered prompt; errors block the loop with `BLOCKED:` and exit 2, warnings log to `.loops/<name>/validate.out` and the loop proceeds (`scripts/run_loop.sh:25-32`).
 
 3. **Iterate `kimi -p`** — for `i` in `1..max_iter` (default 10):
    - Run `kimi -p "$(cat prompt.rendered.md)"`, capture output (`run_loop.sh:25-29`).
@@ -29,6 +29,7 @@ A shell framework that drives `kimi -p` review/resolve loops. The calling skill 
 - `skills/loops/SKILL.md` — main skill definition: usage, steps, caller contract, boundaries, and example wiring from `pr-review`
 - `skills/loops/scripts/run_loop.sh` — the loop driver: renders prompt, runs `kimi -p` iterations, checks `DONE:`/`BLOCKED:`, manages `.loops/` logs
 - `skills/loops/scripts/cavemanize.sh` — pre-compression filter: strips filler words, collapses whitespace, preserves fenced code blocks; reads stdin, writes stdout
+- `skills/loops/scripts/validate.sh` — pre-kimi gate: compares the template against the rendered prompt and fails (exit 2, `BLOCKED:`) on lost headings, fences, URLs, or inline codes; logs warnings to `.loops/<name>/validate.out`
 
 ## See also
 

--- a/skills/loops/SKILL.md
+++ b/skills/loops/SKILL.md
@@ -21,7 +21,8 @@ scripts/run_loop.sh <prompt.md> [max_iter=10] [workdir]
 ## Steps
 
 1. **START** — `cd` to `[workdir]`. Render `<prompt.md>` through `scripts/cavemanize.sh` (compresses prose; preserves code, identifiers, errors).
-2. **LOOP** — for `i` in `1..max_iter`:
+2. **GATE** — run `scripts/validate.sh` on the template vs the rendered prompt. Errors (lost heading, fence, URL, inline code) BLOCK the loop with `BLOCKED:` and exit 2; warnings log to `.loops/<name>/validate.out` and the loop proceeds.
+3. **LOOP** — for `i` in `1..max_iter`:
    - Run `kimi -p "<rendered>"`, capture output.
    - Check for `DONE:` or `BLOCKED:`.
    - On `DONE:` — write artifact path, exit 0.
@@ -37,6 +38,7 @@ scripts/run_loop.sh <prompt.md> [max_iter=10] [workdir]
 |---|---|
 | `scripts/run_loop.sh` | The framework. Args: `prompt.md [max_iter] [workdir]`. |
 | `scripts/cavemanize.sh` | Compresses prose to caveman form. Reads stdin, writes stdout. |
+| `scripts/validate.sh` | Pre-kimi gate. Compares template vs rendered prompt; errors block, warnings log. |
 
 ## Caller contract
 

--- a/skills/loops/scripts/run_loop.sh
+++ b/skills/loops/scripts/run_loop.sh
@@ -20,6 +20,14 @@ RENDERED="$LOGS/prompt.rendered.md"
 # Render the template (cavemanize on initial render)
 bash "$SCRIPT_DIR/cavemanize.sh" < "$PROMPT_FILE" > "$RENDERED"
 
+# Pre-kimi gate: ensure cavemanize preserved structural invariants
+# (headings, code blocks, URLs, inline codes). Errors block; warnings log.
+if ! bash "$SCRIPT_DIR/validate.sh" "$PROMPT_FILE" "$RENDERED" > "$LOGS/validate.out" 2>&1; then
+  echo "BLOCKED: pre-kimi validate failed (see $LOGS/validate.out)" >&2
+  head -1 "$LOGS/validate.out" >&2 || true
+  exit 2
+fi
+
 for i in $(seq 1 "$MAX_ITER"); do
   echo "[run_loop] iter $i / $MAX_ITER — calling kimi -p"
 

--- a/skills/loops/scripts/validate.sh
+++ b/skills/loops/scripts/validate.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# validate.sh — ensure compressed file preserves critical content from original
+# Inspired by JuliusBrussee/caveman validate.py
+# (https://github.com/JuliusBrussee/caveman/blob/main/skills/caveman-compress/scripts/validate.py)
+#
+# Severity split:
+#   ERROR (blocks run_loop.sh)  — structural breakage: missing heading, fence
+#                                  count drift, lost URL, lost inline code.
+#   WARNING (advisory only)     — content drift inside a preserved structure:
+#                                  cavemanize.sh uses sed, which is line-agnostic
+#                                  about ``` fences, so content inside may drift.
+#                                  Cosmetic heading/whitespace drift also WARN.
+#
+# Limits vs validate.py:
+#   * Indented fences (CommonMark 0-3 leading spaces) supported — matches at
+#     column 0-3 only; deeper indentation skipped.
+#   * Bash 4+ regex used; macOS default bash 3.2 will not run this. Loops
+#     already requires bash; forge users are Linux/CI.
+#   * Path regex is a pragmatic heuristic adapted from validate.py:7 — not
+#     CommonMark-precise. WARN-level only, so imprecision does not block.
+#
+# Usage: validate.sh <original> <compressed>
+# Exit:  0 valid (no errors; warnings allowed) | 1 invalid | 2 usage error
+#
+# Stdout: one finding per line. ERROR: / WARNING: prefix. Final line:
+#         "Valid: yes" or "Valid: no".
+
+set -euo pipefail
+
+[[ $# -eq 2 ]] || { echo "usage: validate.sh <original> <compressed>" >&2; exit 2; }
+orig="$1"
+comp="$2"
+[[ -f "$orig" ]] || { echo "FAIL: original not found: $orig" >&2; exit 2; }
+[[ -f "$comp" ]] || { echo "FAIL: compressed not found: $comp" >&2; exit 2; }
+
+errors=0
+warnings=0
+err()  { echo "ERROR: $*";   errors=$((errors+1)); }
+warn() { echo "WARNING: $*"; warnings=$((warnings+1)); }
+
+# Fence state machine. Mutates globals in_fence, fence_char, fence_len.
+in_fence=0; fence_char=""; fence_len=0
+
+_fence_open_at() {
+  # $1 = line. Sets globals and returns 0 if line opens a fence.
+  if [[ "$1" =~ ^([[:space:]]{0,3})([\`~]{3,})(.*)$ ]]; then
+    local chars="${BASH_REMATCH[2]}"
+    fence_char="${chars:0:1}"
+    fence_len="${#chars}"
+    in_fence=1
+    return 0
+  fi
+  return 1
+}
+
+_fence_close_at() {
+  # $1 = line. Closes if same char and length >= opening length, no info string.
+  if [[ "$1" =~ ^([[:space:]]{0,3})([\`~]+)([[:space:]]*)$ ]]; then
+    local chars="${BASH_REMATCH[2]}"
+    local rest="${BASH_REMATCH[3]}"
+    local c="${chars:0:1}" l="${#chars}"
+    if [[ "$c" == "$fence_char" && $l -ge $fence_len ]]; then
+      in_fence=0; fence_char=""; fence_len=0
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Extract fenced code blocks. One block per stdout line; internal newlines
+# encoded as \x1e (record separator) so block boundaries survive command
+# substitution. Unclosed fences silently skipped (matches validate.py:65-69).
+extract_fences() {
+  in_fence=0; fence_char=""; fence_len=0
+  local line block=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if (( in_fence )); then
+      if _fence_close_at "$line"; then
+        block+=$'\n'"$line"
+        printf '%s\n' "${block//$'\n'/$'\x1e'}"
+        block=""
+      else
+        block+=$'\n'"$line"
+      fi
+    elif _fence_open_at "$line"; then
+      block="$line"
+    fi
+  done < "$1"
+}
+
+# Headings: prints "<level>\t<text>" per heading, one per line.
+extract_headings() {
+  local line
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^(#{1,6})[[:space:]]+(.+)$ ]]; then
+      printf '%s\t%s\n' "${#BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    fi
+  done < "$1"
+}
+
+extract_urls() {
+  grep -oE 'https?://[^[:space:])]+' "$1" | sort -u || true
+}
+
+extract_paths() {
+  # Pragmatic port of validate.py:7 — POSIX ERE. WARN-level only.
+  grep -oE '(\./|\.\./|/|[A-Za-z]:\\)[[:alnum:]_./\\-]+|[[:alnum:]_.\-]+[/\\][[:alnum:]_./\\-]+' "$1" \
+    | sort -u || true
+}
+
+count_bullets() {
+  local n
+  n=$(grep -cE '^[[:space:]]*[-*+][[:space:]]+' "$1" || true)
+  echo "${n:-0}"
+}
+
+# Inline codes: fence-aware walker. Outputs "count\tcode" per unique code,
+# sorted by code (so comm can compare multisets).
+extract_inline_codes_counter() {
+  in_fence=0; fence_char=""; fence_len=0
+  declare -A count=()
+  local line
+  while IFS= read -r line; do
+    if (( in_fence )); then
+      _fence_close_at "$line" || true
+      continue
+    fi
+    if _fence_open_at "$line"; then continue; fi
+    # extract backtick-delimited spans; iterate via BASH_REMATCH consumption
+    while [[ "$line" =~ \`([^\`]+)\` ]]; do
+      local code="${BASH_REMATCH[1]}"
+      count[$code]=$(( ${count[$code]:-0} + 1 ))
+      line="${line#*"${BASH_REMATCH[0]}"}"
+    done
+  done < "$1"
+  for k in "${!count[@]}"; do
+    printf '%d\t%s\n' "${count[$k]}" "$k"
+  done | sort -k2
+}
+
+# --- validators ---
+
+validate_headings() {
+  local o c co cc
+  o="$(extract_headings "$orig")"
+  c="$(extract_headings "$comp")"
+  co=$(printf '%s\n' "$o" | grep -c . || true)
+  cc=$(printf '%s\n' "$c" | grep -c . || true)
+  co=${co:-0}; cc=${cc:-0}
+  if [[ "$co" != "$cc" ]]; then
+    err "heading count mismatch: $co vs $cc"
+  fi
+  if [[ -n "$o" && "$o" != "$c" ]]; then
+    warn "heading text/order changed"
+  fi
+}
+
+validate_code_blocks() {
+  local o c nb_o nb_c
+  o="$(extract_fences "$orig")"
+  c="$(extract_fences "$comp")"
+  nb_o=$(printf '%s\n' "$o" | grep -c . || true)
+  nb_c=$(printf '%s\n' "$c" | grep -c . || true)
+  nb_o=${nb_o:-0}; nb_c=${nb_c:-0}
+  if [[ "$nb_o" == "0" && "$nb_c" == "0" ]]; then return; fi
+  if [[ "$nb_o" != "$nb_c" ]]; then
+    err "code block count mismatch: $nb_o vs $nb_c"
+  elif [[ "$o" != "$c" ]]; then
+    warn "code block content drifted (cavemanize is line-agnostic about fences)"
+  fi
+}
+
+validate_urls() {
+  local o c lost added
+  o="$(extract_urls "$orig")"
+  c="$(extract_urls "$comp")"
+  lost=$(comm -23 <(printf '%s\n' "$o") <(printf '%s\n' "$c") || true)
+  added=$(comm -13 <(printf '%s\n' "$o") <(printf '%s\n' "$c") || true)
+  if [[ -n "$lost" ]]; then
+    err "URL lost: $(echo "$lost" | tr '\n' ' ' | sed 's/ $//')"
+  fi
+  if [[ -n "$added" ]]; then
+    warn "URL added: $(echo "$added" | tr '\n' ' ' | sed 's/ $//')"
+  fi
+}
+
+validate_paths() {
+  local o c lost added
+  o="$(extract_paths "$orig")"
+  c="$(extract_paths "$comp")"
+  lost=$(comm -23 <(printf '%s\n' "$o") <(printf '%s\n' "$c") || true)
+  added=$(comm -13 <(printf '%s\n' "$o") <(printf '%s\n' "$c") || true)
+  if [[ -n "${lost}${added}" ]]; then
+    warn "path set drift: lost=[$(echo "$lost" | tr '\n' ',' | sed 's/,$//')], added=[$(echo "$added" | tr '\n' ',' | sed 's/,$//')]"
+  fi
+}
+
+validate_bullets() {
+  local b1 b2 diff
+  b1=$(count_bullets "$orig")
+  b2=$(count_bullets "$comp")
+  if [[ "$b1" == "0" ]]; then return; fi
+  diff=$(awk -v a="$b1" -v b="$b2" 'BEGIN { d = a - b; if (d < 0) d = -d; printf "%.0f", (d / a) * 100 }')
+  if [[ "$diff" -gt 15 ]]; then
+    warn "bullet count drift: $b1 -> $b2 (${diff}%)"
+  fi
+}
+
+validate_inline_codes() {
+  local o c lost added
+  o="$(extract_inline_codes_counter "$orig")"
+  c="$(extract_inline_codes_counter "$comp")"
+  lost=$(comm -23 <(printf '%s\n' "$o") <(printf '%s\n' "$c") || true)
+  added=$(comm -13 <(printf '%s\n' "$o") <(printf '%s\n' "$c") || true)
+  if [[ -n "$lost" ]]; then
+    err "inline code lost or reduced: $(echo "$lost" | tr '\n' ';' | sed 's/;$//')"
+  fi
+  if [[ -n "$added" ]]; then
+    warn "inline code added: $(echo "$added" | tr '\n' ';' | sed 's/;$//')"
+  fi
+}
+
+validate_headings
+validate_code_blocks
+validate_urls
+validate_paths
+validate_bullets
+validate_inline_codes
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "Valid: no"
+  exit 1
+fi
+echo "Valid: yes"
+exit 0


### PR DESCRIPTION
## TL;DR

Cavemanize drops filler words and leading whitespace inside fenced code blocks, with no detection. This PR adds `validate.sh` and wires it as a pre-`kimi -p` gate that blocks structural loss (heading, fence, URL, inline code) and warns on content drift inside preserved structures.

**Files to review (4, +248 / -2):**

| File | Why |
|---|---|
| `skills/loops/scripts/validate.sh` *(new, start here)* | Bash 4+ port of JuliusBrussee/caveman `validate.py`. Six checks across headings, fenced code, URLs, paths, bullets, inline codes. |
| `skills/loops/scripts/run_loop.sh` | Calls `validate.sh` between initial render and the first `kimi -p` call. Error → `BLOCKED:` + exit 2. |
| `skills/loops/SKILL.md` | Adds the gate to the Scripts table and a new GATE step in the flow. |
| `docs/guides/loops.md` | Documents `validate.sh` in Files in this skill and the gate semantics in step 2. |

## Reviewer notes

- **Severity split.** Errors block; warnings log to `.loops/<name>/validate.out` and the loop proceeds. Keeps existing prompts working even with the known cavemanize fence-content drift.
- **Single-shot, not per-iter.** Validation runs once on the initial render, not every loop iteration. After iter 0 the running prompt contains `kimi -p`'s reply and is no longer comparable to the template. Cavemanize is deterministic — if the first render validates, every re-render does.
- **Bash 4+ regex, not POSIX sh.** macOS default bash 3.2 will not run this. Same baseline as `run_loop.sh` already requires.
- **Limits.** Indented fences (CommonMark 0-3 leading spaces) supported at column 0-3; deeper indentation skipped. Path regex is a heuristic — WARN-level only, so imprecision does not block.
- **Reference.** Patterned after JuliusBrussee/caveman `skills/caveman-compress/scripts/validate.py`. Commit message cites the URL; nothing copied verbatim.

## Tests

Manual verification only — the repo has no `tests/loops/` fixture convention yet, and KISS wins over standing up infra for this change. Five cases run during development:

| Case | Expect | Result |
|---|---|---|
| Clean pair with one fence | `Valid: yes`, exit 0 | Pass |
| URL removed from rendered prompt | `ERROR: URL lost …`, exit 1 | Pass |
| Fence-content drift only | `WARNING: code block content drifted …`, exit 0 | Pass |
| Heading removed | `ERROR: heading count mismatch …`, exit 1 | Pass |
| Nested 4-backtick outer / 3-backtick inner roundtrip | `Valid: yes`, exit 0 | Pass |
| `run_loop.sh` on a prompt with inline filler code | `BLOCKED: pre-kimi validate failed`, exit 2 before any `kimi -p` call | Pass |

---
_This PR description was generated with [AI assistance](https://raw.githubusercontent.com/tdhopper/dotfiles2.0/master/.claude/skills/creating-pull-requests/SKILL.md)._
