### PR TITLE
Remove stale Roo Code and Zoo Code references, adapt docs to Kimi Code CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
-about: Report unexpected behavior in an agent mode
-title: "fix(<mode-slug>): <brief description>"
+about: Report unexpected behavior in a skill
+title: "fix(<skill-name>): <brief description>"
 labels: bug, triage
 assignees: ''
 ---
@@ -10,47 +10,48 @@ assignees: ''
 
 A clear description of what the unexpected behavior is.
 
-## 🤖 Affected Mode
+## 🤖 Affected Skill
 
-Which mode(s) are affected? Check all that apply:
+Skill path (e.g. skills/wayfinder/SKILL.md):
 
-- [ ] Orchestrator (`orchestrator`)
-- [ ] Ask (`ask`)
-- [ ] Architect (`architect`)
-- [ ] Subtask Orchestrator (`subtask-orchestrator`)
-- [ ] Git (`git`)
+Which area does the affected skill belong to? Check all that apply:
+
+- [ ] Orchestration flow (forge, forge-flow, loops)
+- [ ] Communication (caveman, caveman-commit, caveman-review, ste100, conventional-commits)
+- [ ] Planning (wayfinder, grilling, prototype, deep-research, planning-and-task-breakdown, domain-modeling)
+- [ ] Execution (using-git-worktrees, subagent-driven-development, dispatching-parallel-agents, finishing-a-development-branch, verification-before-completion, pr-review, pr-resolve, creating-pull-requests, resolving-merge-conflicts, use-git-identity)
+- [ ] Bootstrap (forge-init, forge-setup, forge-docs, forge-cleanup, git-issue-tracker)
+- [ ] Sidecars (12-factor-app, kiss-principle, frontend-design, forge-tailwindcss-conventions, forge-eu-accessibility, forge-seo)
 
 ## 📋 Steps to Reproduce
 
-1. Import the affected mode YAML into Roo Code
-2. Activate the mode and provide the following prompt: _'...'_
+1. Load the skill in your harness (Kimi Code CLI: `/skill:<name>`)
+2. Provide the following prompt: _'...'_
 3. Observe the behavior at step...
 4. ...
 
 ## ✅ Expected Behavior
 
-What did you expect the mode to do according to the pipeline?
+What did you expect the skill to do according to the skill's SKILL.md contract?
 
 ## ❌ Actual Behavior
 
 What actually happened? Include any relevant output or observed behavior.
 
-## 🔗 Pipeline Impact
+## 🔗 Flow Impact
 
-Does this affect the orchestration pipeline? If so, how?
+Does this affect the forge flow? If so, how?
 
-- [ ] Blocks downstream modes from functioning
-- [ ] Produces incorrect output that propagates
-- [ ] Causes mode to exit prematurely
-- [ ] Violates the pipeline protocol (e.g., unauthorized mode switch)
-- [ ] No pipeline impact — isolated issue
+- [ ] Blocks other skills from functioning
+- [ ] Produces incorrect output that propagates into the forge flow
+- [ ] Breaks the skill's own contract (trigger, procedure, boundaries)
+- [ ] No flow impact — isolated issue
 
 ## 📎 Context
 
-- **Roo Code version:**
-- **VS Code version:**
-- **Mode YAML file version/commit:** 
-- **Other active modes during the session:**
+- **Harness (e.g. Kimi Code CLI) and version:**
+- **Skill file version/commit:**
+- **Other skills loaded during the session:**
 
 ## 📝 Additional Information
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
-about: Propose a new mode or enhancement to the agent stack
-title: "feat(<mode-slug>): <brief description>"
+about: Propose a new skill or enhancement to the skill set
+title: "feat(<skill-name>): <brief description>"
 labels: enhancement, triage
 assignees: ''
 ---
@@ -10,24 +10,25 @@ assignees: ''
 
 A clear description of the feature or enhancement you'd like to propose.
 
-## 🤖 Affected Mode(s)
+## 🤖 Affected Skill(s)
 
-Which mode(s) would this affect?
+Which skill(s) would this affect?
 
-- [ ] Orchestrator (`orchestrator`)
-- [ ] Ask (`ask`)
-- [ ] Architect (`architect`)
-- [ ] Subtask Orchestrator (`subtask-orchestrator`)
-- [ ] Git (`git`)
-- [ ] **New mode** — proposed slug: ``
+- [ ] Orchestration flow (forge, forge-flow, loops)
+- [ ] Communication (caveman, caveman-commit, caveman-review, ste100, conventional-commits)
+- [ ] Planning (wayfinder, grilling, prototype, deep-research, planning-and-task-breakdown, domain-modeling)
+- [ ] Execution (using-git-worktrees, subagent-driven-development, dispatching-parallel-agents, finishing-a-development-branch, verification-before-completion, pr-review, pr-resolve, creating-pull-requests, resolving-merge-conflicts, use-git-identity)
+- [ ] Bootstrap (forge-init, forge-setup, forge-docs, forge-cleanup, git-issue-tracker)
+- [ ] Sidecars (12-factor-app, kiss-principle, frontend-design, forge-tailwindcss-conventions, forge-eu-accessibility, forge-seo)
+- [ ] **New skill** — proposed name: ``
 
 ## 🎯 Problem Statement
 
-What problem does this solve? What limitation have you encountered in the current agent stack?
+What problem does this solve? What limitation have you encountered in the current skill set?
 
-## 🔄 Pipeline Integration
+## 🔄 Flow Integration
 
-How would this feature integrate into the existing orchestration pipeline?
+How would this feature integrate into the existing forge flow (map → resolve → plan → work → verify → review → resolve)?
 
 ```mermaid
 flowchart LR
@@ -42,15 +43,15 @@ Describe the expected behavior in detail:
 1. **Trigger:** When should this behavior activate?
 2. **Input:** What context does it need?
 3. **Output:** What should it produce?
-4. **Handoff:** How does it pass control to the next mode?
+4. **Handoff:** Which skills does it load or hand off to?
 
 ## 🧪 Testing Plan
 
-How would you verify this works correctly within the full pipeline?
+How would you verify this works correctly within the full skill set?
 
-- [ ] Tested in isolation with the mode imported
-- [ ] Tested within the full pipeline (all modes active)
-- [ ] Verified no regression in other modes
+- [ ] Loaded and exercised in Kimi Code CLI (`/skill:<name>`)
+- [ ] Exercised alongside the skills it interacts with
+- [ ] Verified no regression in referencing skills
 
 ## 📝 Additional Context
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question / Discussion
-about: Ask a question or start a discussion about the agent stack
+about: Ask a question or start a discussion about the skill set
 title: "docs: <brief topic>"
 labels: question
 assignees: ''
@@ -10,16 +10,17 @@ assignees: ''
 
 A clear description of your question or the topic you'd like to discuss.
 
-## 🤖 Related Mode(s)
+## 🤖 Related Skill(s)
 
-Which mode(s) does this relate to?
+Which skill(s) does this relate to?
 
-- [ ] Orchestrator
-- [ ] Ask
-- [ ] Architect
-- [ ] Subtask Orchestrator
-- [ ] Git
-- [ ] General / Pipeline-wide
+- [ ] Orchestration flow (forge, forge-flow, loops)
+- [ ] Communication (caveman, caveman-commit, caveman-review, ste100, conventional-commits)
+- [ ] Planning (wayfinder, grilling, prototype, deep-research, planning-and-task-breakdown, domain-modeling)
+- [ ] Execution (using-git-worktrees, subagent-driven-development, dispatching-parallel-agents, finishing-a-development-branch, verification-before-completion, pr-review, pr-resolve, creating-pull-requests, resolving-merge-conflicts, use-git-identity)
+- [ ] Bootstrap (forge-init, forge-setup, forge-docs, forge-cleanup, git-issue-tracker)
+- [ ] Sidecars (12-factor-app, kiss-principle, frontend-design, forge-tailwindcss-conventions, forge-eu-accessibility, forge-seo)
+- [ ] General / flow-wide
 
 ## 📋 Context
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           body: |
             ## 📦 Release Assets
 
-            RooForge is a skills-only collection after the rebuild in PR #24. Each release ships the full `skills/` set and the `mcp/` helper scripts; the previous Roo Code mode YAMLs, slash-command pack, and native rule are gone.
+            This release ships the full `skills/` set and the `mcp/` helper scripts.
 
             ### Skills & MCP (zip archives)
 
@@ -61,8 +61,8 @@ jobs:
 
             ### Installation
 
-            1. Download `skills.zip` and extract to your harness skills directory (e.g. `~/.kimi-code/skills/`, `~/.roo/skills/`, etc.).
-            2. Download `mcp.zip` and extract to your harness MCP directory (e.g. `~/.kimi-code/mcp/`, `~/.roo/mcp/`).
+            1. Download `skills.zip` and extract to your harness skills directory (e.g. `~/.kimi-code/skills/` or `~/.agents/skills/`).
+            2. Download `mcp.zip` and extract to your harness MCP directory (e.g. `~/.kimi-code/mcp/`).
             3. Load the `forge` skill — it is the always-on orchestrator and entry point for the flow.
             4. On non-Kimi harnesses, follow `skills/forge-setup/SKILL.md` for portable adaptation.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,13 @@ jobs:
 
             | Archive | Contents |
             |---------|----------|
-            | `skills.zip` | All 35 forge skills (orchestrator: `forge`; bootstrap: `forge-flow`, `forge-setup`; sidecars: `caveman`, `conventional-commits`, `deep-research`, `planning-and-task-breakdown`, `kiss-principle`, plus the rest of the curated set) — extract to your harness skills directory |
-            | `mcp.zip` | MCP server scripts (`pdf-curl-server.sh`, `pdf-curl-server.ps1`) — extract to your harness MCP directory |
+            | `skills.zip` | All 35 forge skills (orchestrator: `forge`; bootstrap: `forge-flow`, `forge-setup`; sidecars: `caveman`, `conventional-commits`, `deep-research`, `planning-and-task-breakdown`, `kiss-principle`, plus the rest of the curated set) — extract to your skills parent directory (contains top-level skills/) |
+            | `mcp.zip` | MCP server scripts (`pdf-curl-server.sh`, `pdf-curl-server.ps1`) — extract to your harness home (contains top-level mcp/) |
 
             ### Installation
 
-            1. Download `skills.zip` and extract to your harness skills directory (e.g. `~/.kimi-code/skills/` or `~/.agents/skills/`).
-            2. Download `mcp.zip` and extract to your harness MCP directory (e.g. `~/.kimi-code/mcp/`).
+            1. Download `skills.zip` and extract into your skills parent directory (e.g. `~/.kimi-code/` or `~/.agents/`) — the archive contains the top-level `skills/` directory.
+            2. Download `mcp.zip` and extract into your harness home (e.g. `~/.kimi-code/`) — the archive contains the top-level `mcp/` directory.
             3. Load the `forge` skill — it is the always-on orchestrator and entry point for the flow.
             4. On non-Kimi harnesses, follow `skills/forge-setup/SKILL.md` for portable adaptation.
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 # Forge working memory (local only)
-.memory/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ Use descriptive feature branches with a conventional prefix:
 | Prefix | Purpose | Example |
 |--------|---------|---------|
 | `feat/` | New skill or skill feature | `feat/new-skill-name` |
-| `fix/` | Bug fix | `fix(forge): correct step order` |
+| `fix/` | Bug fix | `fix/forge-step-order` |
 | `docs/` | Documentation changes | `docs/update-installation-guide` |
-| `refactor/` | Skill refactoring | `refactor(wayfinder): simplify ticket rules` |
+| `refactor/` | Skill refactoring | `refactor/wayfinder-ticket-rules` |
 | `chore/` | Maintenance tasks | `chore/update-workflow` |
 
 > Branch descriptions must use **technical language only**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Contributing to RooForge
 
-First off, thank you for your interest in this project! We appreciate the community's involvement and welcome contributions that improve the agent orchestration workflow.
+First off, thank you for your interest in this project! We appreciate the community's involvement and welcome contributions that improve the forge orchestration flow.
 
 ## ⚠️ Important: Pull Request Policy
 
-**We do not generally accept pull requests.** This repository maintains a carefully curated agent "stack" where each mode is designed to work in concert with the others. Before any PR is considered, it must go through the following process:
+**We do not generally accept pull requests.** This repository maintains a carefully curated skill collection where each skill is designed to work in concert with the others. Before any PR is considered, it must go through the following process:
 
-1. **Testing** - You must thoroughly test your changes by importing the modified YAML files into Zoo Code and verifying that the mode behaves as expected within the full pipeline.
-2. **Evaluation** - We evaluate whether the change actually benefits the intended workflow and orchestration pattern. Changes that introduce inconsistency, break the pipeline, or deviate from the design philosophy will not be accepted.
+1. **Testing** - You must thoroughly test your changes by loading the changed skill in the Kimi Code CLI (slash command `/skill:<name>`) or another harness and exercising its trigger.
+2. **Evaluation** - We evaluate whether the change actually benefits the intended workflow and orchestration pattern. Changes that introduce inconsistency, break the flow, or deviate from the design philosophy will not be accepted.
 3. **Review** - If the change passes testing and evaluation, we will review the implementation details.
 
 If your contribution passes all three stages, we will work with you to merge it.
@@ -31,19 +31,19 @@ Use descriptive feature branches with a conventional prefix:
 
 | Prefix | Purpose | Example |
 |--------|---------|---------|
-| `feat/` | New feature or mode | `feat/add-debug-mode` |
-| `fix/` | Bug fix | `fix/orchestrator-pipeline-order` |
+| `feat/` | New skill or skill feature | `feat/new-skill-name` |
+| `fix/` | Bug fix | `fix(forge): correct step order` |
 | `docs/` | Documentation changes | `docs/update-installation-guide` |
-| `refactor/` | Code/mode refactoring | `refactor/simplify-ask-mode` |
+| `refactor/` | Skill refactoring | `refactor(wayfinder): simplify ticket rules` |
 | `chore/` | Maintenance tasks | `chore/update-workflow` |
 
-> Branch descriptions must use **technical language only** — no pipeline jargon (no "phase", "blueprint", or other pipeline-specific terms in branch names or commit messages).
+> Branch descriptions must use **technical language only**.
 
 ### 3. Make Your Changes
 
-- Edit the relevant `agents/*.yaml` file(s)
-- Ensure YAML syntax is valid
-- Test the mode in Zoo Code within the full pipeline context
+- Edit the relevant `skills/<name>/SKILL.md` (and its companion files)
+- Ensure the YAML frontmatter is valid (`name` + `description` required)
+- Load the changed skill in the Kimi Code CLI (`/skill:<name>`) or another harness and exercise its trigger within the full flow context
 
 ### 4. Commit with Conventional Commits (Extended)
 
@@ -60,10 +60,11 @@ We follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/
 #### Required Format
 
 ```
-feat(architect): add support for multi-repo planning
+feat(wayfinder): add blocking-edge wiring pass
 
-Added ability for the Architect mode to handle cross-repository
-blueprints by accepting multiple codebase contexts.
+Wayfinder tickets can now declare blocking edges between map
+nodes; the wiring pass links each ticket to the tickets it
+blocks so the frontier query surfaces only unblocked work.
 
 Closes #42
 ```
@@ -101,19 +102,20 @@ git push origin feat/my-new-feature
 Then open a PR against the `main` branch on GitHub. Your PR description should include:
 
 - **What** you changed and why
-- **How** you tested the change in Zoo Code
-- **Which modes** are affected
-- **Any pipeline implications** - does this change affect how modes interact?
+- **How** you loaded and exercised the skill
+- **Which skills** are affected
+- **Any cross-skill implications** - does this change affect how skills reference each other?
 
 ## ✅ Testing Checklist
 
 Before submitting a PR, verify:
 
-- [ ] The modified YAML file(s) import successfully into Zoo Code
-- [ ] The mode activates and follows its role definition correctly
-- [ ] The mode integrates properly with the other modes in the pipeline
-- [ ] No YAML syntax errors or broken references
-- [ ] The change aligns with the orchestration philosophy of this stack
+- [ ] The YAML frontmatter is valid (`name` + `description` required)
+- [ ] The frontmatter `description` states when to invoke the skill (triggers, situations, keywords)
+- [ ] The body states what the skill does
+- [ ] Per-skill commit - one scope per commit, per `AGENTS.md`
+- [ ] `README.md` skills table and `docs/guides/<skill>.md` updated when public behavior changed
+- [ ] No stale references to other harnesses
 
 ## 📋 Code of Conduct
 
@@ -125,187 +127,9 @@ Feel free to [open an issue](https://github.com/weselben/RooForge/issues/new) fo
 
 ---
 
-## 🔄 Simulated Agent Flow Walkthrough
+## The Forge Flow
 
-To understand what each mode is expected to do, here is a complete walkthrough of an imaginary task flowing through the entire agent stack.
-
-### Scenario: "Add a REST API endpoint for user preferences"
-
-#### Phase 1 - Intel Acquisition (Ask Mode)
-
-**Input from Orchestrator:** "Research what's needed to add a REST API endpoint for user preferences. Identify the current project stack, existing API patterns, and any relevant libraries."
-
-**What Ask does:**
-1. Searches the codebase for existing API route definitions (e.g., `routes/`, `controllers/`)
-2. Identifies the framework in use (e.g., Express, Fastify, Hono)
-3. Searches the web for best practices and the framework's latest API patterns
-4. Checks `.memory/` for any previously cached intel
-5. Examines existing authentication middleware and database models
-
-**Output - "State of Intel" Report:**
-```
-STATE OF INTEL - User Preferences API Endpoint
-================================================
-Framework: Express.js v4.18 (package.json line 12)
-Existing pattern: /api/v1/* routes in src/routes/
-Auth middleware: requireAuth() from src/middleware/auth.js
-Database: PostgreSQL via Prisma ORM (schema.prisma)
-Existing model: User model exists, no Preferences model
-Relevant files:
-  - src/routes/index.js (route registry)
-  - src/middleware/auth.js
-  - prisma/schema.prisma
-  - src/controllers/userController.js
-Constraints:
-  - All routes require authentication
-  - API follows RESTful conventions
-  - Response format: { success: boolean, data: any, error?: string }
-Sources: codebase analysis, Express.js docs (https://expressjs.com/en/4x/api.html)
-```
-
-#### Phase 2 - Architectural Grounding (Architect Mode)
-
-**Input from Orchestrator:** The full Master Context Package (original request + complete State of Intel + constraints).
-
-**What Architect does:**
-1. Analyzes the intel to understand the existing architecture
-2. Designs the new endpoint following established patterns
-3. Breaks the work into phases with individual tasks using /blueprint
-4. Defines verification criteria and checkpoints for each phase
-
-**Output - "Blueprint":**
-```
-BLUEPRINT - User Preferences API Endpoint
-==========================================
-
-Phase 1: MVP — Database & Core API
-  Checkpoint: Preferences model exists, API responds to GET requests
-
-  Task 1.1: Database Schema & Migration
-    Description: Create the Preferences model and migration
-    Acceptance criteria:
-      - Prisma model defines all required fields
-      - Migration runs without errors
-    Verification: Prisma migrate succeeds, model is queryable
-    Dependencies: None
-    Files likely touched: prisma/schema.prisma, migration file
-    Scope: S
-
-  Task 1.2: API Route & Controller
-    Description: Implement GET/PUT /api/v1/user/preferences
-    Acceptance criteria:
-      - GET returns user preferences
-      - PUT updates user preferences
-      - Auth middleware applied
-    Verification: Route responds to requests, auth middleware applied
-    Dependencies: Task 1.1 (model must exist)
-    Files likely touched: src/routes/preferences.js, src/controllers/preferencesController.js
-    Scope: M
-
-Phase 2: Robustness — Validation & Error Handling
-  Checkpoint: Invalid input is properly rejected, errors are handled
-
-  Task 2.1: Input Validation & Error Handling
-    Description: Add validation middleware and error responses
-    Acceptance criteria:
-      - Invalid input returns 400 with descriptive message
-      - Valid input passes through
-    Verification: Invalid input returns 400, valid input passes through
-    Dependencies: Task 1.2 (route must exist)
-    Files likely touched: src/middleware/validatePreferences.js
-    Scope: S
-
-Phase 3: Quality — Tests & Documentation
-  Checkpoint: All tests pass, docs are up to date
-
-  Task 3.1: Tests & Documentation
-    Description: Write integration tests and update API docs
-    Acceptance criteria:
-      - Integration tests cover GET and PUT
-      - API docs reflect new endpoint
-    Verification: Tests pass, docs reflect new endpoint
-    Dependencies: Task 2.1 (full flow must work)
-    Files likely touched: tests/preferences.test.js, docs/api.md
-    Scope: M
-```
-
-#### Phase 3 - Phase-Based Execution (Orchestrator)
-
-**What the Orchestrator does:**
-1. Receives the Blueprint from Architect
-2. Writes out ALL phases and tasks fully before dispatching any
-3. For each task, builds a "Context Envelope" containing:
-   - The task's objective and scope boundary
-   - The relevant Blueprint excerpt
-   - The relevant State of Intel slice
-   - Current project state
-   - Known blockers/risks
-4. Dispatches Task 1.1 to Subtask Orchestrator via `new_task`
-5. Verifies phase checkpoints between phases
-
-#### Phase 4 - Atomic Execution (Subtask Orchestrator + Specialists)
-
-**For Task 1.1 (Database Schema & Migration):**
-
-The Subtask Orchestrator further decomposes into atomic subtasks:
-
-| Subtask | Specialist | Job |
-|---------|-----------|-----|
-| ST-1.1a | Code | Add `Preferences` model to `prisma/schema.prisma` |
-| ST-1.1b | Code | Run `npx prisma migrate dev --name add-preferences` |
-| ST-1.1c | Code | Verify model is queryable with a quick test query |
-
-**What happens step by step:**
-
-1. **Subtask Orchestrator** dispatches ST-1.1a to **Code** mode with full context:
-   - The exact model fields needed (from Blueprint)
-   - The existing schema location (from State of Intel)
-   - The instruction: "Add a Preferences model to prisma/schema.prisma with fields: id, userId, theme, notifications, language. Follow existing model patterns."
-
-2. **Code** mode implements the change and returns via `attempt_completion`:
-   - "Added Preferences model to prisma/schema.prisma (line 45). Fields: id (Int, autoincrement), userId (Int, relation to User), theme (String, default 'system'), notifications (Boolean, default true), language (String, default 'en')."
-
-3. **Subtask Orchestrator** verifies the output matches expectations, then dispatches ST-1.1b.
-
-4. After all subtasks complete, **Subtask Orchestrator** returns to **Orchestrator** with an exhaustive state report.
-
-5. **Orchestrator** evaluates the result, then dispatches **Git** mode to commit Task 1.1.
-
-6. **Git** mode validates staged content, generates commit: `feat(db): add Preferences model and migration`, and returns the commit hash.
-
-7. **Orchestrator** proceeds to Task 1.2, and the cycle repeats. After all tasks in Phase 1 complete, the phase checkpoint is verified before starting Phase 2.
-
-#### Final Flow Summary
-
-```
-User Request
-  → Orchestrator receives
-    → /plan → Subtask-Orchestrator (planning)
-      → /clarify → grill user on scope
-      → /research → Ask (State of Intel)
-      → /clarify → verify findings
-      → Delegate to Architect → Blueprint
-      → Review + summarize for Orchestrator
-    → /execute → Subtask-Orchestrator (per phase)
-      → Phase 1: Task 1.1 → Code → Task 1.2 → Code
-      → /delegate → Git (branch + pull/sync on main, conventional commit)
-      → Phase 2: Task 2.1 → Code
-      → /delegate → Git (conventional commit)
-      → ...
-    → /finalize → Final result to User
-```
-
-### Key Principles Illustrated
-
-| Principle | How It Manifests |
-|-----------|-----------------|
-| **No mode switches** | Every mode returns via `attempt_completion`; the Orchestrator controls all delegation via `new_task` |
-| **Atomic purity** | Each subtask has exactly one verifiable output; no specialist is overloaded |
-| **Explicit context** | Every delegation includes the full relevant context - no mode assumes prior knowledge |
-| **Sequential execution** | Tasks execute one at a time; each phase is committed before the next begins |
-| **Phase checkpoints** | System is verified in a working state between phases |
-| **Planning ownership** | Subtask-Orchestrator owns the full planning lifecycle (clarify → research → architect) |
-| **Git per phase** | Orchestrator delegates Git after every phase — branch setup on main, pull/sync, conventional commit |
+This repository curates the forge orchestration flow: map → resolve → plan → work → verify → review → resolve. The entry point is the **forge** skill at `skills/forge/SKILL.md`; the `README.md` section **The Flow** describes the full orchestration. Read both before proposing changes to how skills reference each other.
 
 ---
 

--- a/docs/guides/caveman.md
+++ b/docs/guides/caveman.md
@@ -11,7 +11,7 @@ Ultra-compressed communication mode that reduces output tokens by ~65% (measured
 
 ## How it works
 
-1. **Mode selection** — Default intensity is `full`. Switch via `/skill:caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off` (SKILL.md:21)
+1. **Mode selection** — Default intensity is `full`. Switch via `/skill:caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off` (SKILL.md:18)
 2. **Compression rules applied** (SKILL.md:23–43):
    - Drop articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging
    - Use fragments; short synonyms (big not extensive, fix not "implement a solution for")

--- a/docs/guides/caveman.md
+++ b/docs/guides/caveman.md
@@ -5,13 +5,13 @@ Ultra-compressed communication mode that reduces output tokens by ~65% (measured
 ## When to load
 
 - User explicitly says: "caveman mode", "talk like caveman", "use caveman", "less tokens", "be brief"
-- User invokes `/caveman` slash command
+- User invokes `/skill:caveman` slash command
 - Token efficiency is explicitly requested
 - Auto-loads as **caveman(ultra)** on every session start via `forge` (mandatory per forge's invariant rules)
 
 ## How it works
 
-1. **Mode selection** — Default intensity is `full`. Switch via `/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off` (SKILL.md:21)
+1. **Mode selection** — Default intensity is `full`. Switch via `/skill:caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra|off` (SKILL.md:21)
 2. **Compression rules applied** (SKILL.md:23–43):
    - Drop articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging
    - Use fragments; short synonyms (big not extensive, fix not "implement a solution for")

--- a/docs/guides/forge-eu-accessibility.md
+++ b/docs/guides/forge-eu-accessibility.md
@@ -43,5 +43,5 @@ EU accessibility compliance — BFSG (German transposition of EAA Directive 2019
 
 ## Notes
 
-- The skill was rewritten for Kimi Code CLI. Previously referenced Roo Code's `run_slash_command` + `web`; verification now uses the harness's native `WebSearch` / `FetchURL` tools.
+- The skill was rewritten for Kimi Code CLI; verification uses the harness's native `WebSearch` / `FetchURL` tools.
 - Framework-agnostic by design — no React/Vue/Angular/Svelte specifics.

--- a/docs/guides/forge-seo.md
+++ b/docs/guides/forge-seo.md
@@ -42,5 +42,5 @@ SEO hub skill with two reference deep-dives: UX/UI SEO (design decisions that im
 
 ## Notes
 
-- The skill was rewritten for Kimi Code CLI. Previously referenced Roo Code's `run_slash_command` + `web`, `read_file`, and `~/.roo/skills/` paths; those now use the harness's `WebSearch` / `FetchURL` tools and relative paths.
+- The skill was rewritten for Kimi Code CLI; it uses the harness's `WebSearch` / `FetchURL` tools and relative paths.
 - The two reference files are unchanged except for the verification-tool substitution.

--- a/docs/guides/forge-tailwindcss-conventions.md
+++ b/docs/guides/forge-tailwindcss-conventions.md
@@ -59,4 +59,4 @@ Tailwind v4 (released January 2025) is CSS-first and zero-config: no `tailwind.c
 
 ## Notes
 
-- The skill was rewritten for Kimi Code CLI. Previously referenced Roo Code "code mode" and `[UXUI]` prefixes; the trigger now lives in the description frontmatter only.
+- The skill was rewritten for Kimi Code CLI; the trigger lives in the description frontmatter only.

--- a/mcp.md
+++ b/mcp.md
@@ -6,7 +6,7 @@
 
 [![SearXNG](https://img.shields.io/badge/SearXNG-Web%20Search-blue)](#searxng)
 [![Curl Download](https://img.shields.io/badge/Curl%20Download-PDF%20Fetch-green)](#curl-download-mcp)
-[![PDF Reader](https://img.shields.io/badge/PDF%20Reader-Text%20Extraction-purple)](#pdf-reader-mcp)
+[![PDF Reader](https://img.shields.io/badge/PDF%20Reader-Text%20Extraction-purple)](#citra-pdf-reader)
 [![Git MCP](https://img.shields.io/badge/Git%20MCP-Structured%20Git-orange)](#git-mcp-server)
 
 *Privacy-respecting search · PDF download · PDF text extraction · Structured git access · MCP-first*
@@ -35,10 +35,10 @@ The Kimi Code CLI uses MCP servers defined in `mcp.json`. Add the entire block b
       "args": ["-c", "exec ~/.kimi-code/mcp/pdf-curl-server.sh"],
       "enabledTools": ["curl_download"]
     },
-    "pdf-reader-mcp": {
+    "citra": {
       "command": "npx",
-      "args": ["-y", "@sylphx/pdf-reader-mcp"],
-      "enabledTools": ["read_pdf", "search_pdf", "inspect_pdf", "ocr_pages", "analyze_regions", "extract_regions", "render_page"]
+      "args": ["-y", "@sylphx/citra"],
+      "enabledTools": ["read_pdf", "search_pdf", "pdf_evidence"]
     },
     "git-mcp-server": {
       "command": "npx",
@@ -187,31 +187,27 @@ python3 --version
 
 ### When to use
 
-- Pulling a PDF from a URL so `pdf-reader-mcp` can extract its text.
+- Pulling a PDF from a URL so `citra` can extract its text.
 - Saving a remote document locally for offline reference without leaving the TUI.
 
 ---
 
-## PDF Reader MCP
+## Citra (PDF Reader)
 
 **Used by:** Research workflows (e.g. the deep-research skill) when the harness has no built-in web search / PDF tooling
 **Purpose:** Extract and parse text from downloaded PDFs
 
-The agent uses [`@sylphx/pdf-reader-mcp`](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp) for reading and extracting structured text from PDF files after they have been downloaded by the `curl-download` server.
+The agent uses [`@sylphx/citra`](https://www.npmjs.com/package/@sylphx/citra) for reading and extracting structured text from PDF files after they have been downloaded by the `curl-download` server. The package was rebranded from `@sylphx/pdf-reader-mcp` (a transitional package id).
 
 | Tool | Purpose | Key Parameters |
 |------|---------|--------------|
-| `read_pdf` | Extract full text or Markdown from a PDF | `sources`, `include_full_text`, `include_markdown`, `maxLength` |
-| `search_pdf` | Search for specific terms within a PDF | `query`, `sources`, `case_sensitive`, `max_matches_per_source` |
-| `inspect_pdf` | Get metadata and structure overview | `sources` |
-| `ocr_pages` | OCR text from scanned/image pages | `sources`, `pages`, `language`, `include_ocr_text_layer` |
-| `analyze_regions` | Analyze document layout regions | `sources`, `pages`, `region_types`, `include_image` |
-| `extract_regions` | Extract specific regions from pages | `sources`, `pages`, `regions`, `include_image` |
-| `render_page` | Render page as image or preview | `sources`, `pages`, `format`, `dpi`, `include_image` |
+| `read_pdf` | Smart default: markdown, tables, structure, OCR, citations | `sources` (required) |
+| `search_pdf` | Find page and snippet matches before deep reading | `query`, `sources` (required) |
+| `pdf_evidence` | Crops, renders, inspect, focused evidence operations | `sources` (required) |
 
 ### Setup
 
-The MCP config block above connects the CLI to the PDF reader server. No additional setup required — `npx` handles the installation automatically. Restart Kimi Code CLI (new session) and run `/mcp` to confirm the server connected before invoking any of its tools.
+The MCP config block above connects the CLI to the Citra server. No additional setup required — `npx` handles the installation automatically. Restart Kimi Code CLI (new session), run `/mcp` to confirm the server connected, then invoke `mcp__citra__read_pdf` in a session.
 
 ### When to use
 

--- a/mcp.md
+++ b/mcp.md
@@ -2,12 +2,12 @@
 
 # 🔌 MCP Servers
 
-**Model Context Protocol servers for the Forge pipeline**
+**Model Context Protocol servers for the Kimi Code CLI**
 
-[![SearXNG](https://img.shields.io/badge/SearXNG-Ask%20Mode-blue)](#searxng)
-[![Curl Download](https://img.shields.io/badge/Curl%20Download-Ask%20Mode-green)](#curl-download-mcp)
-[![PDF Reader](https://img.shields.io/badge/PDF%20Reader-Ask%20Mode-purple)](#pdf-reader-mcp)
-[![Git MCP](https://img.shields.io/badge/Git%20MCP-Git%20Mode-orange)](#git-mcp-server)
+[![SearXNG](https://img.shields.io/badge/SearXNG-Web%20Search-blue)](#searxng)
+[![Curl Download](https://img.shields.io/badge/Curl%20Download-PDF%20Fetch-green)](#curl-download-mcp)
+[![PDF Reader](https://img.shields.io/badge/PDF%20Reader-Text%20Extraction-purple)](#pdf-reader-mcp)
+[![Git MCP](https://img.shields.io/badge/Git%20MCP-Structured%20Git-orange)](#git-mcp-server)
 
 *Privacy-respecting search · PDF download · PDF text extraction · Structured git access · MCP-first*
 
@@ -17,7 +17,7 @@
 
 ## Overview
 
-The Forge pipeline requires three MCP servers for full functionality. Add the entire block below to your Zoo Code MCP settings using the MCP settings view (**Edit Global MCP**). If editing manually, use the global `mcp_settings.json` file for your Zoo Code extension ID (`ZooCodeOrganization.zoo-code`).
+The Kimi Code CLI uses MCP servers defined in `mcp.json`. Add the entire block below to `~/.kimi-code/mcp.json` (user level) or `.kimi-code/mcp.json` (project level), or run `/mcp-config` in the TUI. Project entries override user entries on name clash; run `/mcp` to view connection status.
 
 ```json
 {
@@ -28,17 +28,17 @@ The Forge pipeline requires three MCP servers for full functionality. Add the en
       "env": {
         "SEARXNG_URL": "http://localhost:8088/"
       },
-      "alwaysAllow": ["web_url_read", "searxng_web_search"]
+      "enabledTools": ["web_url_read", "searxng_web_search"]
     },
     "curl-download": {
       "command": "sh",
-      "args": ["-c", "exec ~/.roo/mcp/pdf-curl-server.sh"],
-      "alwaysAllow": ["curl_download"]
+      "args": ["-c", "exec ~/.kimi-code/mcp/pdf-curl-server.sh"],
+      "enabledTools": ["curl_download"]
     },
     "pdf-reader-mcp": {
       "command": "npx",
       "args": ["-y", "@sylphx/pdf-reader-mcp"],
-      "alwaysAllow": ["read_pdf", "search_pdf", "inspect_pdf", "ocr_pages", "analyze_regions", "extract_regions", "render_page"]
+      "enabledTools": ["read_pdf", "search_pdf", "inspect_pdf", "ocr_pages", "analyze_regions", "extract_regions", "render_page"]
     },
     "git-mcp-server": {
       "command": "npx",
@@ -46,7 +46,7 @@ The Forge pipeline requires three MCP servers for full functionality. Add the en
       "env": {
         "GIT_SIGN_COMMITS": "false"
       },
-      "alwaysAllow": [
+      "enabledTools": [
         "git_add",
         "git_blame",
         "git_branch",
@@ -86,27 +86,29 @@ The Forge pipeline requires three MCP servers for full functionality. Add the en
 On Windows, replace the `curl-download` entry in the config above with the PowerShell version:
 
 ```json
-    "curl-download": {
-      "command": "powershell",
-      "args": [
-        "-NoProfile",
-        "-ExecutionPolicy", "Bypass",
-        "-File", "C:\\Users\\%username%\\.roo\\mcp\\pdf-curl-server.ps1"
-      ],
-      "alwaysAllow": ["curl_download"]
-    }
+{
+  "curl-download": {
+    "command": "powershell",
+    "args": [
+      "-NoProfile",
+      "-ExecutionPolicy", "Bypass",
+      "-File", "C:\\Users\\%username%\\.kimi-code\\mcp\\pdf-curl-server.ps1"
+    ],
+    "enabledTools": ["curl_download"]
+  }
+}
 ```
 
-> Requires the [`pdf-curl-server.ps1`](mcp/pdf-curl-server.ps1) script to be copied to `~/.roo/mcp/`.
+> Requires the [`pdf-curl-server.ps1`](mcp/pdf-curl-server.ps1) script to be copied to `~/.kimi-code/mcp/`.
 
 ---
 
 ## SearXNG
 
-**Required by:** Ask mode
+**Used by:** Research workflows (e.g. the deep-research skill) when the harness has no built-in web search / PDF tooling
 **Purpose:** Web search & URL reading for intelligence gathering
 
-Ask mode uses [SearXNG](https://github.com/searxng/searxng) — a privacy-respecting meta-search engine — for real-time web access. Two tools are exposed:
+The agent uses [SearXNG](https://github.com/searxng/searxng) — a privacy-respecting meta-search engine — for real-time web access. Two tools are exposed:
 
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
@@ -126,37 +128,47 @@ docker run -d \
   searxng/searxng:latest
 ```
 
-**Step 2:** The MCP config block above connects Zoo Code to your SearXNG instance. Update `SEARXNG_URL` if your instance runs on a different port or host.
+**Step 2:** The MCP config block above connects the CLI to your SearXNG instance. Update `SEARXNG_URL` if your instance runs on a different port or host.
 
-**Step 3:** Restart Zoo Code → switch to Ask mode → ask a question requiring web search → confirm `searxng_web_search` appears.
+**Step 3:** Restart Kimi Code CLI (new session), run `/mcp` to confirm the server connected, then invoke the tool (e.g. `mcp__searxng__searxng_web_search`) in a session.
 
 <details>
-<summary>📖 What does <code>alwaysAllow</code> do?</summary>
+<summary>📖 What do <code>enabledTools</code> / <code>disabledTools</code> do?</summary>
 
-By default, Zoo Code asks for confirmation before each MCP tool call. Adding tool names to `alwaysAllow` skips confirmation. Recommended for `searxng_web_search` and `web_url_read` since Ask mode relies on frequent search/read cycles.
+MCP server entries accept two optional allow/block lists:
+
+- `enabledTools` — if set, only the listed tools are exposed to the harness. Tools not in the list are hidden.
+- `disabledTools` — if set, the listed tools are hidden while every other tool is exposed.
+
+These lists control which tools the server exposes to the agent; tools not listed are not visible. The lists above are recommended for `searxng_web_search` and `web_url_read` because research flows rely on frequent search/read cycles.
 </details>
+
+### When to use
+
+- Real-time web search during research flows that need information beyond the model's training cutoff.
+- Reading the full body of a URL referenced in a search result.
 
 ---
 
 ## Curl Download MCP
 
-**Required by:** Ask mode
+**Used by:** Research workflows (e.g. the deep-research skill) when the harness has no built-in web search / PDF tooling
 **Purpose:** Download PDFs from URLs via POSIX shell + curl
 
-Ask mode uses the repo-owned `curl-download` MCP server for downloading PDFs from URLs. No `npx` or npm dependency — the server runs directly via `sh` with a POSIX shell script.
+The agent uses the repo-owned `curl-download` MCP server for downloading PDFs from URLs. No `npx` or npm dependency — the server runs directly via `sh` with a POSIX shell script.
 
 | Tool | Purpose | Key Parameters |
 |------|---------|--------------|
-| `curl_download` | Download PDF from URL to `.memory/` | `url` (string, required) |
+| `curl_download` | Download PDF from URL (output dir: `PDF_CURL_OUTPUT_DIR` env, default current directory) | `url` (string, required) |
 
 ### Setup
 
 **Step 1:** Create the MCP directory and make the server script executable:
 
 ```bash
-mkdir -p ~/.roo/mcp
+mkdir -p ~/.kimi-code/mcp
 chmod +x mcp/pdf-curl-server.sh
-cp mcp/pdf-curl-server.sh ~/.roo/mcp/
+cp mcp/pdf-curl-server.sh ~/.kimi-code/mcp/
 ```
 
 **Step 2:** Ensure dependencies are installed. The script requires `curl` and either `jq` or `python3`:
@@ -172,16 +184,21 @@ jq --version
 python3 --version
 ```
 
-**Step 3:** The MCP config block above connects Zoo Code to the curl-download server. Restart Zoo Code → switch to Ask mode → run `curl_download` → confirm PDF is downloaded to `.memory/`.
+**Step 3:** The MCP config block above connects the CLI to the curl-download server. Restart Kimi Code CLI (new session), run `/mcp` to confirm the server connected, then invoke `mcp__curl-download__curl_download` in a session.
+
+### When to use
+
+- Pulling a PDF from a URL so `pdf-reader-mcp` can extract its text.
+- Saving a remote document locally for offline reference without leaving the TUI.
 
 ---
 
 ## PDF Reader MCP
 
-**Required by:** Ask mode
+**Used by:** Research workflows (e.g. the deep-research skill) when the harness has no built-in web search / PDF tooling
 **Purpose:** Extract and parse text from downloaded PDFs
 
-Ask mode uses [`@sylphx/pdf-reader-mcp`](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp) for reading and extracting structured text from PDF files after they have been downloaded by the `curl-download` server.
+The agent uses [`@sylphx/pdf-reader-mcp`](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp) for reading and extracting structured text from PDF files after they have been downloaded by the `curl-download` server.
 
 | Tool | Purpose | Key Parameters |
 |------|---------|--------------|
@@ -195,16 +212,21 @@ Ask mode uses [`@sylphx/pdf-reader-mcp`](https://www.npmjs.com/package/@sylphx/p
 
 ### Setup
 
-The MCP config block above connects Zoo Code to the PDF reader server. No additional setup required — `npx` handles the installation automatically.
+The MCP config block above connects the CLI to the PDF reader server. No additional setup required — `npx` handles the installation automatically. Restart Kimi Code CLI (new session) and run `/mcp` to confirm the server connected before invoking any of its tools.
+
+### When to use
+
+- Pulling quotes or citations from a PDF that `curl-download` has already saved locally.
+- Inspecting the structure of a PDF before deciding which pages or regions to extract.
 
 ---
 
 ## Git MCP Server
 
-**Required by:** Git mode
+**Used by:** Git-heavy flows when typed git tools are preferred over the CLI
 **Purpose:** Structured git operations with MCP-first, CLI fallback
 
-Git mode uses [`@cyanheads/git-mcp-server`](https://github.com/cyanheads/git-mcp-server) for typed, validated git operations. When MCP fails or a tool doesn't exist, CLI is the fallback.
+The agent uses [`@cyanheads/git-mcp-server`](https://github.com/cyanheads/git-mcp-server) for typed, validated git operations. When MCP fails or a tool doesn't exist, CLI is the fallback.
 
 | Tool | Purpose |
 |------|---------|
@@ -224,7 +246,7 @@ Git mode uses [`@cyanheads/git-mcp-server`](https://github.com/cyanheads/git-mcp
 | `git_log` | View commit history with filtering |
 | `git_merge` | Merge branches together |
 | `git_pull` | Fetch and integrate remote changes |
-| `git_rebase` | Rebase commits onto another branch |
+| `git_rebase` | Rebase commits onto another base |
 | `git_reflog` | View reference logs for recovery |
 | `git_remote` | Manage remote repositories |
 | `git_reset` | Reset HEAD to specified state |
@@ -242,32 +264,25 @@ Git mode uses [`@cyanheads/git-mcp-server`](https://github.com/cyanheads/git-mcp
 |------|--------|
 | `git_push` | Safety: prevents accidental pushes. Push manually via CLI when ready. |
 
-> `git_push` is in `disabledTools` and intentionally excluded from `alwaysAllow`. The pipeline commits locally — push is a destructive remote operation that should be explicitly confirmed by the user.
+> `git_push` is listed in `disabledTools` and intentionally not in `enabledTools`. Local commits are encouraged; push is a destructive remote operation that should be explicitly confirmed by the user.
 
 ### Setup
 
-The MCP config block above connects Zoo Code to the git-mcp-server. `GIT_SIGN_COMMITS` defaults to `false` — set to `true` if you want GPG-signed commits.
+The MCP config block above connects the CLI to the git-mcp-server. `GIT_SIGN_COMMITS` defaults to `false` — set to `true` if you want GPG-signed commits.
 
-**Verify:** Restart Zoo Code → switch to Git mode → run `git_status` → confirm structured response.
+**Verify:** Restart Kimi Code CLI (new session), run `/mcp` to confirm the server connected, then invoke `mcp__git-mcp-server__git_status` in a session.
 
 <details>
 <summary>📖 Why is <code>git_push</code> disabled?</summary>
 
-The orchestration pipeline commits locally but does not auto-push. Push is destructive, public-facing operation. Git mode stages and commits all changes, then instructs the user to push manually. To enable, add `"git_push"` to `alwaysAllow` and remove from `disabledTools`.
+The orchestration flow commits locally but does not auto-push. Push is a destructive, public-facing operation. The agent stages and commits all changes, then instructs the user to push manually. To enable, add `"git_push"` to `enabledTools` and remove it from `disabledTools`.
 </details>
 
----
+### When to use
 
-## Impact on the Pipeline
-
-| Mode | SearXNG | Curl Download MCP | PDF Reader MCP | Git MCP |
-|------|---------|-------------------|----------------|---------|
-| **Orchestrator** | Indirect (via Ask) | — | — | Indirect (via Git) |
-| **Ask** | **Direct** | **Direct** | **Direct** | — |
-| **Architect** | Indirect (via Ask) | — | — | — |
-| **Subtask Orchestrator** | Indirect (via Ask) | — | — | Indirect (via Git) |
-| **Code** | — | — | — | — |
-| **Git** | — | — | — | **Direct** |
+- Long-running flows that need validated, typed git operations rather than raw shell commands.
+- Branch and worktree juggling (create, switch, list) without the agent having to assemble CLI invocations.
+- Generating a changelog or session wrap-up from recent history.
 
 ---
 

--- a/mcp.md
+++ b/mcp.md
@@ -86,18 +86,17 @@ The Kimi Code CLI uses MCP servers defined in `mcp.json`. Add the entire block b
 On Windows, replace the `curl-download` entry in the config above with the PowerShell version:
 
 ```json
-{
   "curl-download": {
     "command": "powershell",
     "args": [
       "-NoProfile",
       "-ExecutionPolicy", "Bypass",
-      "-File", "C:\\Users\\%username%\\.kimi-code\\mcp\\pdf-curl-server.ps1"
+      "-File", "C:\\Users\\<your-username>\\.kimi-code\\mcp\\pdf-curl-server.ps1"
     ],
     "enabledTools": ["curl_download"]
   }
-}
 ```
+*Replace <your-username> with your Windows username.*
 
 > Requires the [`pdf-curl-server.ps1`](mcp/pdf-curl-server.ps1) script to be copied to `~/.kimi-code/mcp/`.
 

--- a/mcp/pdf-curl-server.ps1
+++ b/mcp/pdf-curl-server.ps1
@@ -90,11 +90,10 @@ function Handle-CurlDownload {
     # Sanitize basename and build output path (matches shell behavior)
     $basename = [System.IO.Path]::GetFileName($Url) -replace '[^a-zA-Z0-9._-]', '_'
     $timestamp = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
-    $outputPath = ".memory/pdf-$timestamp-$basename"
+    $outputDir = if ($env:PDF_CURL_OUTPUT_DIR) { $env:PDF_CURL_OUTPUT_DIR } else { '.' }
+    $outputPath = Join-Path $outputDir "pdf-$timestamp-$basename"
 
-    if (-not (Test-Path ".memory")) {
-        New-Item -ItemType Directory -Path ".memory" -Force | Out-Null
-    }
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
 
     try {
         Invoke-WebRequest -Uri $Url -OutFile $outputPath `

--- a/mcp/pdf-curl-server.ps1
+++ b/mcp/pdf-curl-server.ps1
@@ -104,7 +104,14 @@ function Handle-CurlDownload {
         return
     }
 
-    $result = "{`"content`":[{`"type`":`"text`",`"text`":`"Downloaded PDF to $outputPath (Content-Type: $contentType)`"}],`"isError`":false}"
+    $resultObj = @{
+        content = @(@{
+            type = 'text'
+            text = "Downloaded PDF to $outputPath (Content-Type: $contentType)"
+        })
+        isError = $false
+    }
+    $result = $resultObj | ConvertTo-Json -Compress
     Send-Result $Id $result
 }
 

--- a/mcp/pdf-curl-server.sh
+++ b/mcp/pdf-curl-server.sh
@@ -81,9 +81,10 @@ handle_curl_download() {
 
     _basename=$(basename "$_url" | sed 's/[^a-zA-Z0-9._-]/_/g')
     _timestamp=$(date +%s)
-    _output_path=".memory/pdf-${_timestamp}-${_basename}"
+    _out_dir="${PDF_CURL_OUTPUT_DIR:-.}"
+    _output_path="${_out_dir}/pdf-${_timestamp}-${_basename}"
 
-    mkdir -p .memory
+    mkdir -p "$_out_dir"
 
     if ! curl -sfL --max-time 30 -o "$_output_path" "$_url" 2>/dev/null; then
         send_error "$_id" -32602 "Download failed for $_url"


### PR DESCRIPTION
## TL;DR

The repo references a deleted Roo Code / Zoo Code YAML-mode stack in user-facing docs, issue templates, release notes, and helper scripts. These references name modes (Ask, Architect, Git) and config surfaces (`mcp_settings.json`, `~/.roo/`, `.memory/`) that do not exist in the current skills-only collection. The PR removes these references. Where a Kimi Code CLI equivalent exists, the docs and scripts now point at it. Where no equivalent exists, the text is harness-agnostic.

**Files to review (13, +177 / -334):**

| File | Why |
|---|---|
| `CONTRIBUTING.md` *(start here)* | Replaces the deleted YAML-mode pipeline with a skills-focused contributing guide. Drops the simulated walkthrough. |
| `mcp.md` | Rewrites the MCP guide for Kimi Code CLI `mcp.json` (user/project), `/mcp-config`, `/mcp`, `enabledTools`/`disabledTools`. Drops `alwaysAllow` and Zoo Code. The PDF reader section now targets the canonical `@sylphx/citra` package (`read_pdf`, `search_pdf`, `pdf_evidence`). |
| `mcp/pdf-curl-server.sh`, `mcp/pdf-curl-server.ps1` | Output directory now honors `PDF_CURL_OUTPUT_DIR` (default current directory). Removes the `.memory/` hardcoding. The PowerShell result is serialized with `ConvertTo-Json`, so Windows paths no longer break the JSON-RPC response. |
| `.github/workflows/release.yml` | Release notes drop the Roo Code historical line. Install paths match the archives: `skills.zip` and `mcp.zip` extract into their parent directory (`~/.kimi-code/` or `~/.agents/`), not into the skills/MCP subdirectory. |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Mode checkboxes become a skill path plus six area checkboxes. Steps to reproduce target skill loading, not YAML import. |
| `.github/ISSUE_TEMPLATE/feature_request.md` | New-skill proposals; flow integration; testing plan. |
| `.github/ISSUE_TEMPLATE/question.md` | Skill-area list replaces the mode list. |
| `docs/guides/caveman.md`, `docs/guides/forge-eu-accessibility.md`, `docs/guides/forge-seo.md`, `docs/guides/forge-tailwindcss-conventions.md` | Drop historical "previously referenced Roo Code" notes and the stale `/caveman` slash-command mention. |
| `.gitignore` | Drop the `.memory/` entry. Nothing writes there now. |

## Why

The pre-rebuild mode stack (Orchestrator, Ask, Architect, Subtask Orchestrator, Code, Git modes; `agents/*.yaml`; `new_task`; `attempt_completion`; `/blueprint`; `mcp_settings.json`; `~/.roo/`; `.memory/`) was removed in PR #24. The references that survive in the tree describe a product that does not exist in this repo. They mislead users who follow the contributing guide, the MCP guide, or the issue templates.

## How

1. Scrubbed deprecated terms (Zoo Code, Roo Code, modes, `agents/*.yaml`, `new_task`, `attempt_completion`, `/blueprint`, `/clarify`, `/execute`, `/finalize`, `mcp_settings.json`, `~/.roo/`, `.memory/`). Verified via grep over the tracked tree; `docs/adr/` history is exempt.
2. Replaced with research-verified Kimi Code CLI equivalents fetched from the official docs in this session: `mcp.json` at user and project level, `/skill:<name>` invocation, `enabledTools`/`disabledTools`, `/mcp`, `/mcp-config`.
3. Made harness-agnostic where no Kimi Code equivalent exists: the `.memory/` output directory becomes the `PDF_CURL_OUTPUT_DIR` environment variable (default current directory). "Required by Ask mode" and "Required by Git mode" become capability-based attributions.
4. Follow-up fixes from review: the PDF reader package was rebranded to `@sylphx/citra` — the config, tool table, and prose now use the canonical name and the three real tools. Release-note install steps extract archives into the parent directory, matching the archive layout. The PowerShell download result uses `ConvertTo-Json` for correct escaping.

## Reviewer notes

- **Start with CONTRIBUTING.md.** The deleted walkthrough (Phases 1–4, modes, `/blueprint`, `attempt_completion`) is the largest removal. Read the new "The Forge Flow" pointer at the bottom of the file.
- **mcp.md is the most mechanically changed file.** The overview JSON block parses. The Windows alternative block is a bare paste-in fragment by design — it replaces one entry inside the user's `mcpServers` map. The PDF reader section documents `@sylphx/citra`; one sentence keeps the old package name on purpose to document the rebrand.
- **The two pdf-curl scripts only gained the output-dir parameterization and the JSON serialization fix.** The `curl` + `jq` / `python3` fallback logic is untouched. `bash -n` passes; `pwsh` is not installed in this environment, so the PowerShell file was verified by diff inspection.
- **The issue templates drop the word "mode" entirely.** The six skill-area checkboxes enumerate all 35 skills in the repo.
- **docs/guides/caveman.md now uses `/skill:caveman`.** `skills/caveman/SKILL.md` still says `/caveman` (upstream-vendored, out of scope here; see Follow-up).
- **Focus area:** the mcp.md Overview JSON block (the `alwaysAllow` to `enabledTools` conversion, the citra server entry) and the release.yml install steps.

## Tests

No automated suite in this repo (skills and docs only). Verified by:

- Banned-terms grep passes over the tracked tree (`--exclude-dir=docs --exclude-dir=.git --exclude-dir=.worktrees`): zero hits for deprecated-product terms, mode nouns plus `.memory`, and the fabricated `mcp.md` config surface (`KIMI_CODE_HOME`, `permission.rules`, `config.toml`). Only remaining hit is `docs/adr/0003`, exempt history.
- `bash -n mcp/pdf-curl-server.sh` exits 0.
- `node` JSON.parse on the mcp.md overview block: valid. The Windows block is a paste-in fragment, not a standalone document.
- `js-yaml` parse of `.github/workflows/release.yml`: clean.
- `grep -n 'pdf-reader-mcp' mcp.md`: one hit, the intentional rebrand note.
- `git diff --stat` confirms 13 files, each within its listed scope.

## Follow-up

- `skills/caveman/SKILL.md` still references `/caveman` (frontmatter description and Persistence section). The guide now uses `/skill:caveman`. The file is upstream-vendored content; decide in a follow-up whether to patch locally or sync upstream.
- `.gitignore` now holds only the orphan comment `# Forge working memory (local only)`. Harmless. A follow-up can delete it or add `.worktrees/` instead.

---

_This PR description was generated with [AI assistance](https://raw.githubusercontent.com/tdhopper/dotfiles2.0/master/.claude/skills/creating-pull-requests/SKILL.md)._
