### PR TITLE
docs(mcp): pin pdf-reader-mcp to v3.0.18 with verified 3-tool surface

### DIFF
--- a/mcp.md
+++ b/mcp.md
@@ -6,7 +6,7 @@
 
 [![SearXNG](https://img.shields.io/badge/SearXNG-Web%20Search-blue)](#searxng)
 [![Curl Download](https://img.shields.io/badge/Curl%20Download-PDF%20Fetch-green)](#curl-download-mcp)
-[![PDF Reader](https://img.shields.io/badge/PDF%20Reader-Text%20Extraction-purple)](#citra-pdf-reader)
+[![PDF Reader](https://img.shields.io/badge/PDF%20Reader-Text%20Extraction-purple)](#pdf-reader-mcp)
 [![Git MCP](https://img.shields.io/badge/Git%20MCP-Structured%20Git-orange)](#git-mcp-server)
 
 *Privacy-respecting search · PDF download · PDF text extraction · Structured git access · MCP-first*
@@ -35,9 +35,9 @@ The Kimi Code CLI uses MCP servers defined in `mcp.json`. Add the entire block b
       "args": ["-c", "exec ~/.kimi-code/mcp/pdf-curl-server.sh"],
       "enabledTools": ["curl_download"]
     },
-    "citra": {
+    "pdf-reader-mcp": {
       "command": "npx",
-      "args": ["-y", "@sylphx/citra"],
+      "args": ["-y", "@sylphx/pdf-reader-mcp@3.0.18"],
       "enabledTools": ["read_pdf", "search_pdf", "pdf_evidence"]
     },
     "git-mcp-server": {
@@ -187,27 +187,27 @@ python3 --version
 
 ### When to use
 
-- Pulling a PDF from a URL so `citra` can extract its text.
+- Pulling a PDF from a URL so `pdf-reader-mcp` can extract its text.
 - Saving a remote document locally for offline reference without leaving the TUI.
 
 ---
 
-## Citra (PDF Reader)
+## PDF Reader MCP
 
 **Used by:** Research workflows (e.g. the deep-research skill) when the harness has no built-in web search / PDF tooling
 **Purpose:** Extract and parse text from downloaded PDFs
 
-The agent uses [`@sylphx/citra`](https://www.npmjs.com/package/@sylphx/citra) for reading and extracting structured text from PDF files after they have been downloaded by the `curl-download` server. The package was rebranded from `@sylphx/pdf-reader-mcp` (a transitional package id).
+The agent uses [`@sylphx/pdf-reader-mcp`](https://www.npmjs.com/package/@sylphx/pdf-reader-mcp) (pinned to v3.0.18, the last TypeScript build; the 4.x line is a transitional package id for the rebranded [`@sylphx/citra`](https://www.npmjs.com/package/@sylphx/citra) and ships the same three tools) for reading and extracting structured text from PDF files after they have been downloaded by the `curl-download` server.
 
 | Tool | Purpose | Key Parameters |
 |------|---------|--------------|
 | `read_pdf` | Smart default: markdown, tables, structure, OCR, citations | `sources` (required) |
 | `search_pdf` | Find page and snippet matches before deep reading | `query`, `sources` (required) |
-| `pdf_evidence` | Crops, renders, inspect, focused evidence operations | `sources` (required) |
+| `pdf_evidence` | Focused evidence operations: `inspect`, `render_page`, `extract_regions`, `ocr_pages`, `analyze_regions` | `sources` (required), operation-specific options |
 
 ### Setup
 
-The MCP config block above connects the CLI to the Citra server. No additional setup required — `npx` handles the installation automatically. Restart Kimi Code CLI (new session), run `/mcp` to confirm the server connected, then invoke `mcp__citra__read_pdf` in a session.
+The MCP config block above connects the CLI to the PDF reader server. No additional setup required — `npx` handles the installation automatically. Restart Kimi Code CLI (new session), run `/mcp` to confirm the server connected, then invoke `mcp__pdf-reader-mcp__read_pdf` in a session.
 
 ### When to use
 


### PR DESCRIPTION
## TL;DR

The mcp.md PDF reader section now points at the original `@sylphx/pdf-reader-mcp` package pinned to v3.0.18 and documents the tool surface the repo actually ships: `read_pdf`, `search_pdf`, `pdf_evidence` (with `inspect`, `render_page`, `extract_regions`, `ocr_pages`, `analyze_regions` as `pdf_evidence` operations). A prior review pass had switched the entry to `@sylphx/citra`; this PR reverts to the original package identity while keeping the verified 3-tool documentation.

**Files to review (1, +8 / -8):**

| File | Why |
|---|---|
| `mcp.md` *(only file)* | Revert the citra switch to `@sylphx/pdf-reader-mcp@3.0.18`; correct the tool table to the real 3-tool surface; note the 4.x transitional-id rebrand. |

## Why

The original Roo Code-era doc listed seven flat tools that never matched the package. A prior review pass (PR #29) fixed this by switching to the canonical `@sylphx/citra` package. The user prefers to stay on the original `@sylphx/pdf-reader-mcp` identity, so this PR keeps the verified 3-tool surface but points at the pinned historical version.

## How

1. Temp-cloned `SylphxAI/pdf-reader-mcp` at v3.0.18 (the last TypeScript build before the citra transition) and read `src/index.ts`: the server registers exactly three tools — `read_pdf`, `search_pdf`, `pdf_evidence`. The five extra names in the old config were never real.
2. Checked the v3.2.2 README and v3.0.18 release notes: `pdf_evidence` is the single evidence tool that carries `inspect`, `render_page`, `extract_regions`, `ocr_pages`, and `analyze_regions` as operations.
3. Checked npm registry dist-tags: `latest` = 4.1.3 (citra-transitional). Pinning to `@3.0.18` documents the verified stable version.
4. Rewrote the config entry (server key `pdf-reader-mcp`, args `["-y", "@sylphx/pdf-reader-mcp@3.0.18"]`, `enabledTools: ["read_pdf", "search_pdf", "pdf_evidence"]`), the section heading, the tool table (3 rows), and the setup/verify lines. One remaining `@sylphx/citra` mention is intentional — it documents the rebrand path.

## Reviewer notes

- The mcp.md Overview JSON block parses. The Windows alternative block is a bare paste-in fragment by design.
- The tool table now names `pdf_evidence` and lists its five operations explicitly. Readers who used the old 7-tool config should map `inspect_pdf` → `pdf_evidence` with the `inspect` operation, and so on.
- If you later want to move to the canonical package, only the server key, args, and the setup tool name change (`mcp__citra__*`).

## Tests

- `node` JSON.parse on the mcp.md overview block: valid.
- `grep -ni 'citra' mcp.md`: one hit, the intentional rebrand note.
- `git diff --stat`: 1 file, 8 insertions, 8 deletions — only the documented regions changed.

## Links

- Original package: https://github.com/SylphxAI/pdf-reader-mcp (v3.0.18)
- Canonical package: https://www.npmjs.com/package/@sylphx/citra

---

_This PR description was generated with [AI assistance](https://raw.githubusercontent.com/tdhopper/dotfiles2.0/master/.claude/skills/creating-pull-requests/SKILL.md)._
